### PR TITLE
update for xdsl version 0.23.0

### DIFF
--- a/practical/general/local.md
+++ b/practical/general/local.md
@@ -50,7 +50,7 @@ For more details about building LLVM or troubleshooting you can visit the [LLVM 
 ## Installing xDSL
 
 >**Note**
-> This tutorial is currently tested with version 0.12.1 of xDSL, so that is the version we will obtain here. 
+> This tutorial is currently tested with version 0.23.0 of xDSL, so that is the version we will obtain here. 
 
 You have two options to install xDSL, you can either get the latest release via pip or download the source from GitHub. The benefit of using pip is that it will install the requiresite Python packages too, whereas when you execute from source you must get these manually (via pip). 
 
@@ -59,7 +59,7 @@ You have two options to install xDSL, you can either get the latest release via 
 You can install xDSL from pip by executing the following:
 
 ```bash
-user@local:~$ pip install xdsl==0.12.1
+user@local:~$ pip install xdsl==0.23.0
 ```
 
 ### Installing and running from source
@@ -69,7 +69,7 @@ To install and run from source you will need to clone the xDSL GitHub repository
 ```bash
 user@local:~$ git clone https://github.com/xdslproject/xdsl.git
 user@local:~$ cd xdsl
-user@local:~$ git checkout tags/v0.12.1
+user@local:~$ git checkout tags/v0.23.0
 ```
 
 You will then need to append the top level to your _PYTHONPATH_, for instance, assuming you have cloned xDSL into your home directory:

--- a/practical/one/README.md
+++ b/practical/one/README.md
@@ -2,4 +2,4 @@
 
 Please see the [exercise_one.md](exercise_one.md) file for detailed instructions
 
-This tutorial has been tested with version 0.12.1 of xDSL and LLVM 16, these are the default versions on ARCHER2 (see [login and access instructions](https://github.com/xdslproject/training-intro/blob/main/practical/general/ARCHER2.md)) and we have also provided [local machine instructions](https://github.com/xdslproject/training-intro/blob/main/practical/general/local.md) for setting up the environment yourself on another machine if you are following this tutorial externally.
+This tutorial has been tested with version 0.23.0 of xDSL and LLVM 16, these are the default versions on ARCHER2 (see [login and access instructions](https://github.com/xdslproject/training-intro/blob/main/practical/general/ARCHER2.md)) and we have also provided [local machine instructions](https://github.com/xdslproject/training-intro/blob/main/practical/general/local.md) for setting up the environment yourself on another machine if you are following this tutorial externally.

--- a/practical/src/for_to_parallel.py
+++ b/practical/src/for_to_parallel.py
@@ -1,5 +1,6 @@
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, SSAValue, Region, Block, MLContext, BlockArgument
+from xdsl.ir import Operation, SSAValue, Region, Block, BlockArgument
+from xdsl.context import MLContext
 from xdsl.dialects import scf, arith
 from dataclasses import dataclass
 from xdsl.passes import ModulePass
@@ -7,7 +8,8 @@ from xdsl.pattern_rewriter import (GreedyRewritePatternApplier,
                                    PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, op_type_rewrite_pattern)
 
-matched_operations={"arith.addf": arith.Addf, "arith.addi": arith.Addi}
+matched_operations = {"arith.addf": arith.Addf, "arith.addi": arith.Addi}
+
 
 class ApplyForToParallelRewriter(RewritePattern):
 
@@ -20,58 +22,59 @@ class ApplyForToParallelRewriter(RewritePattern):
         """
         # First we get the body of the for loop and detach it (as will attack to the
         # parallel loop when we create it)
-        loop_body=for_loop.body.blocks[0]
+        loop_body = for_loop.body.blocks[0]
         for_loop.body.detach_block(0)
+
         # Now get the arguments to the yield at the end of the for loop and the arguments
         # to the loop block too
-        yielded_args=list(loop_body.ops.last.arguments)
-        block_args=list(loop_body.args)
+        yielded_args = list(loop_body.ops.last.arguments)
+        block_args = list(loop_body.args)
 
-        ops_to_add=[]
+        ops_to_add = []
         for op in loop_body.ops:
-          # We go through each operation in the loop body and see if it is one that needs
-          # a reduction operation applied to it
-          if op.name in matched_operations.keys():
-            # We need to find if it is the LHS or RHS that is based upon the argument to the block
-            # if it is neither then ignore this as it is not going to be updated from one iteration
-            # to the next so no need to wrap in a reduction
-            if isinstance(op.lhs, BlockArgument):
-              block_arg_op=op.lhs
-              other_arg=op.rhs
-            elif isinstance(op.rhs, BlockArgument):
-              block_arg_op=op.rhs
-              other_arg=op.lhs
-            else:
-              continue
+            # We go through each operation in the loop body and see if it is one that needs
+            # a reduction operation applied to it
+            if op.name in matched_operations.keys():
+                # We need to find if it is the LHS or RHS that is based upon the argument to the block
+                # if it is neither then ignore this as it is not going to be updated from one iteration
+                # to the next so no need to wrap in a reduction
+                if isinstance(op.lhs, BlockArgument):
+                    block_arg_op = op.lhs
+                    other_arg = op.rhs
+                elif isinstance(op.rhs, BlockArgument):
+                    block_arg_op = op.rhs
+                    other_arg = op.lhs
+                else:
+                    continue
 
-            # Now detach op from the body and remove from those arguments yielded
-            # and arguments to the top level block
-            op.detach()
-            yielded_args.remove(op.results[0])
-            block_args.remove(block_arg_op)
+                # Now detach op from the body and remove from those arguments yielded
+                # and arguments to the top level block
+                op.detach()
+                yielded_args.remove(op.results[0])
+                block_args.remove(block_arg_op)
 
-            # Create a new block for this reduction operation which has the type of
-            # operation LHS and RHS present
-            block_arg_types=[] # Needs to be completed!
-            block = Block(arg_types=block_arg_types)
+                # Create a new block for this reduction operation which has the type of
+                # operation LHS and RHS present
+                block_arg_types = []  # Needs to be completed!
+                block = Block(arg_types=block_arg_types)
 
-            # Retrieve the dialect operation to instantiate
-            op_instance=matched_operations[op.name]
-            assert op_instance is not None
+                # Retrieve the dialect operation to instantiate
+                op_instance = matched_operations[op.name]
+                assert op_instance is not None
 
-            # Instantiate the dialect operation and create a reduce return operation
-            # that will return the result, then add these operations to the block
-            new_op=op_instance.get(block.args[0], block.args[1])
-            reduce_result=None # Needs to be completed!
-            block.add_ops([new_op, reduce_result])
+                # Instantiate the dialect operation and create a reduce return operation
+                # that will return the result, then add these operations to the block
+                new_op = op_instance(block.args[0], block.args[1])
+                reduce_result = None  # Needs to be completed!
+                block.add_ops([new_op, reduce_result])
 
             # Create the reduce operation and add to the top level block
-            reduce_op=None # Needs to be completed!
+            reduce_op = None  # Needs to be completed!
             ops_to_add.append(reduce_op)
 
         # Create a new top level block which will have far fewer arguments
         # as none of the reduction arguments are now present here
-        new_block=Block(arg_types=[arg.typ for arg in block_args])
+        new_block = Block(arg_types=[arg.type for arg in block_args])
         new_block.add_ops(ops_to_add)
 
         for op in loop_body.ops:
@@ -80,22 +83,21 @@ class ApplyForToParallelRewriter(RewritePattern):
 
         # We have a yield at the end of the block which yields non reduction
         # arguments
-        new_yield=scf.Yield.get(*yielded_args)
+        new_yield = scf.Yield(*yielded_args)
         new_block.erase_op(new_block.ops.last)
         new_block.add_op(new_yield)
 
         # Create our parallel operation and replace the for loop with this
-        parallel_loop=None # Needs to be completed!
+        parallel_loop = None  # Needs to be completed!
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConvertForToParallel(ModulePass):
-  """
-  This is the entry point for the transformation pass which will then apply the rewriter
-  """
-  name = 'for-to-parallel'
+    """
+    This is the entry point for the transformation pass which will then apply the rewriter
+    """
+    name = 'for-to-parallel'
 
-  def apply(self, ctx: MLContext, input_module: ModuleOp):
-    applyRewriter=ApplyForToParallelRewriter()
-    walker = PatternRewriteWalker(GreedyRewritePatternApplier([applyRewriter]), apply_recursively=False)
-    walker.rewrite_module(input_module)
+    def apply(self, ctx: MLContext, input_module: ModuleOp):
+        walker = PatternRewriteWalker(GreedyRewritePatternApplier([]), apply_recursively=False)
+        walker.rewrite_module(input_module)

--- a/practical/src/python_compiler.py
+++ b/practical/src/python_compiler.py
@@ -57,7 +57,7 @@ class Analyzer(ast.NodeVisitor):
         Handle assignment, we visit the RHS and then create the tiny_py Assign IR operation
         """
         val=self.visit(node.value)
-        return tiny_py.Assign.get(node.targets[0].id, val)
+        return tiny_py.Assign(node.targets[0].id, val)
 
     def visit_Module(self, node):
         """
@@ -67,7 +67,7 @@ class Analyzer(ast.NodeVisitor):
         contents=[]
         for a in node.body:
             contents.append(self.visit(a))
-        return tiny_py.Module.get(contents)
+        return tiny_py.Module(contents)
 
     def visit_FunctionDef(self, node):
         """
@@ -83,19 +83,19 @@ class Analyzer(ast.NodeVisitor):
                 # parser function that you will complete in exercise two,
                 # so we don't want to include that in the operations
                 contents.append(operation)
-        return tiny_py.Function.get(node.name, None, [], contents)
+        return tiny_py.Function(node.name, None, [], contents)
 
     def visit_Constant(self, node):
         """
         A literal constant value
         """
-        return tiny_py.Constant.get(node.value)
+        return tiny_py.Constant(node.value)
 
     def visit_Name(self, node):
         """
         Variable name
         """
-        return tiny_py.Var.get(node.id)
+        return tiny_py.Var(node.id)
 
     def visit_For(self, node):
         """
@@ -125,7 +125,7 @@ class Analyzer(ast.NodeVisitor):
             raise Exception("Operation "+str(node.op)+" not recognised")
         lhs=self.visit(node.left)
         rhs=self.visit(node.right)
-        return tiny_py.BinaryOperation.get(op_str, lhs, rhs)
+        return tiny_py.BinaryOperation(op_str, lhs, rhs)
 
     def visit_Call(self, node):
         """
@@ -136,7 +136,7 @@ class Analyzer(ast.NodeVisitor):
         for arg in node.args:
             arguments.append(self.visit(arg))
         builtin_fn=self.isFnCallBuiltIn(node.func.id)
-        return tiny_py.CallExpr.get(node.func.id, arguments, builtin=builtin_fn)
+        return tiny_py.CallExpr(node.func.id, arguments, builtin=builtin_fn)
 
     def visit_Expr(self, node):
         """

--- a/practical/src/tiny_py_to_standard.py
+++ b/practical/src/tiny_py_to_standard.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 from xdsl.dialects.builtin import (StringAttr, ModuleOp, IntegerAttr, IntegerType,
-      ArrayAttr, i32, i64, f32, f64, IndexType, DictionaryAttr,
-      Float16Type, Float32Type, Float64Type, FloatAttr, UnitAttr,
-      DenseIntOrFPElementsAttr, VectorType, SymbolRefAttr)
+                                   ArrayAttr, i32, i64, f32, f64, IndexType, DictionaryAttr,
+                                   Float16Type, Float32Type, Float64Type, FloatAttr, UnitAttr,
+                                   DenseIntOrFPElementsAttr, VectorType, SymbolRefAttr)
 from xdsl.dialects import func, arith, cf, memref, scf, llvm
-from xdsl.ir import Operation, Attribute, ParametrizedAttribute, Region, Block, SSAValue, BlockArgument, MLContext
+from xdsl.ir import Operation, Attribute, ParametrizedAttribute, Region, Block, SSAValue, BlockArgument
+from xdsl.context import MLContext
+from xdsl.traits import IsTerminator
+
 import tiny_py
 from xdsl.passes import ModulePass
 from util.list_ops import flatten
@@ -21,22 +24,24 @@ to generate and executable
 
 # A match between operation names and their standard dialect representations, there are
 # two entries for each representing the integer and float corresponding operation
-binary_arith_op_matching={"add": [arith.Addi, arith.Addf], "sub":[arith.Subi, arith.Subf],
-                          "mult": [arith.Muli, arith.Mulf], "div": [arith.DivSI, arith.Divf]}
+binary_arith_op_matching = {"add": [arith.Addi, arith.Addf], "sub": [arith.Subi, arith.Subf],
+                            "mult": [arith.Muli, arith.Mulf], "div": [arith.DivSI, arith.Divf]}
 
-builtin_function_name_mapping={"print": "printf"}
+builtin_function_name_mapping = {"print": "printf"}
 
-string_index=0
-global_declarations=[]
+string_index = 0
+global_declarations = []
+
 
 class GetAssignedVariables(Visitor):
-  def __init__(self):
-    self.assigned_vars=[]
+    def __init__(self):
+        self.assigned_vars = []
 
-  def traverse_assign(self, assign:tiny_py.Assign):
-    var_name=assign.var_name.data
-    if var_name not in self.assigned_vars:
-      self.assigned_vars.append(var_name)
+    def traverse_assign(self, assign: tiny_py.Assign):
+        var_name = assign.var_name.data
+        if var_name not in self.assigned_vars:
+            self.assigned_vars.append(var_name)
+
 
 @dataclass
 class SSAValueCtx:
@@ -61,18 +66,21 @@ class SSAValueCtx:
         self.dictionary[identifier] = ssa_value
 
     def copy(self):
-      ssa=SSAValueCtx()
-      ssa.dictionary=dict(self.dictionary)
-      return ssa
+        ssa = SSAValueCtx()
+        ssa.dictionary = dict(self.dictionary)
+        return ssa
 
-def translate_program(input_module: Module) -> ModuleOp:
+
+def translate_program(input_module: ModuleOp) -> ModuleOp:
     # create an empty global context
     global_ctx = SSAValueCtx()
     body = Region()
     block = Block()
     for top_level_entry in input_module.ops:
-      for module in top_level_entry.children.blocks[0].ops:
-        translate_toplevel(global_ctx, module, block)
+        assert isinstance(top_level_entry, tiny_py.Module)
+        top_level_entry: tiny_py.Module
+        for module in top_level_entry.children.blocks[0].ops:
+            translate_toplevel(global_ctx, module, block)
 
     assert (len(block.ops)) == 1 and isinstance(block.ops.first, func.FuncOp)
 
@@ -80,16 +88,18 @@ def translate_program(input_module: Module) -> ModuleOp:
     body.add_block(block)
     return ModuleOp(body)
 
+
 def translate_toplevel(ctx: SSAValueCtx, op: Operation, block) -> Operation:
     if isinstance(op, tiny_py.Function):
         block.add_op(translate_fun_def(ctx, op))
 
+
 def translate_fun_def(ctx: SSAValueCtx,
-                      fn_def: tinypy.Function) -> Operation:
+                      fn_def: tiny_py.Function) -> Operation:
     """
     Translates a function definition into the func standard dialect
     """
-    routine_name = fn_def.attributes["fn_name"]
+    routine_name = fn_def.properties["fn_name"]
 
     body = Region()
     block = Block()
@@ -97,12 +107,12 @@ def translate_fun_def(ctx: SSAValueCtx,
     # Create a new nested scope and relate parameter identifiers with SSA values of block arguments
     c = SSAValueCtx(dictionary=dict(), parent_scope=ctx)
 
-    arg_types=[]
-    arg_names=[]
+    arg_types = []
+    arg_names = []
 
-    body_contents=[]
+    body_contents = []
     for op in fn_def.body.blocks[0].ops:
-        res=translate_def_or_stmt(c, op)
+        res = translate_def_or_stmt(c, op)
         if res is not None:
             body_contents.append(res)
 
@@ -116,10 +126,11 @@ def translate_fun_def(ctx: SSAValueCtx,
     # To keep it very simple we have an empty list of arguments to our function definition
     # Also to keep it simple we hard code the name to be main, as this is the program
     # entry point (could instead use routine_name.data to obtain the string value)
-    function_ir=func.FuncOp.from_region("main", arg_types, [], body)
-    function_ir.attributes["sym_visibility"]=StringAttr("public")
+    function_ir = func.FuncOp.from_region("main", arg_types, [], body)
+    function_ir.attributes["sym_visibility"] = StringAttr("public")
 
     return function_ir
+
 
 def translate_def_or_stmt(ctx: SSAValueCtx,
                           op: Operation) -> List[Operation]:
@@ -131,6 +142,7 @@ def translate_def_or_stmt(ctx: SSAValueCtx,
         return ops
     # operation must have been translated by now
     raise Exception(f"Could not translate `{op}' as a definition or statement")
+
 
 def try_translate_stmt(ctx: SSAValueCtx,
                        op: Operation) -> Optional[List[Operation]]:
@@ -150,8 +162,9 @@ def try_translate_stmt(ctx: SSAValueCtx,
 
     return None
 
+
 def translate_stmt(ctx: SSAValueCtx,
-                  op: Operation) -> List[Operation]:
+                   op: Operation) -> List[Operation]:
     """
     Translates op as a statement.
     If op is an expression, returns a list of the translated Operations.
@@ -163,6 +176,7 @@ def translate_stmt(ctx: SSAValueCtx,
     else:
         return ops
 
+
 def translate_return(ctx: SSAValueCtx,
                      return_stmt: tiny_py.Return) -> List[Operation]:
     """
@@ -170,37 +184,41 @@ def translate_return(ctx: SSAValueCtx,
     """
     return [func.Return.get([])]
 
+
 def translate_loop(ctx: SSAValueCtx,
-                  loop_stmt: tiny_py.Loop) -> List[Operation]:
+                   loop_stmt: tiny_py.Loop) -> List[Operation]:
     """
     Translates a loop into the standard dialect scf while construct
     """
 
     # First off lets translate the from (start) and to (end) expressions of the loop
-    start_expr, start_ssa=translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
-    end_expr, end_ssa=None, None # Needs to be completed!
+    start_expr, start_ssa = translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
+    end_expr, end_ssa = None, None  # Needs to be completed!
+
     # The scf.for operation requires indexes as the type, so we cast these to
     # the indextype using the IndexCastOp of the arith dialect
-    start_cast = arith.IndexCastOp.get(start_ssa, IndexType())
-    end_cast = None # Needs to be completed!
+    start_cast = arith.IndexCastOp(start_ssa, IndexType())
+    end_cast = None  # Needs to be completed!
+
     # The scf.for operation requires a step (number of iterations to increment
     # each iteration, we just create this as 1)
-    step_op = arith.Constant.create(attributes={"value": IntegerAttr.from_index_int_value(1)}, result_types=[IndexType()])
+    step_op = arith.Constant.create(properties={"value": IntegerAttr.from_index_int_value(1)},
+                                    result_types=[IndexType()])
 
     # This is slightly more complex, we need to provide as arguments to the block
     # variables which are updated and then yield these out. We use a visitor
     # to visit all assignments and gather the names of the variables that are assigned
-    assigned_var_finder=GetAssignedVariables()
+    assigned_var_finder = GetAssignedVariables()
     for op in loop_stmt.body.blocks[0].ops:
         assigned_var_finder.traverse(op)
 
     # Based on the above information we build the list of block arguments, the first
     # element is always the operand which represents the current loop iteration
     # which is of type index
-    block_arg_types=[IndexType()]
-    block_args=[]
+    block_arg_types = [IndexType()]
+    block_args = []
     for var_name in assigned_var_finder.assigned_vars:
-        block_arg_types.append(ctx[StringAttr(var_name)].typ)
+        block_arg_types.append(ctx[StringAttr(var_name)].type)
         block_args.append(ctx[StringAttr(var_name)])
 
     # Create the block with our arguments, we will be putting into here the
@@ -212,34 +230,35 @@ def translate_loop(ctx: SSAValueCtx,
     # to the block
     c = SSAValueCtx(dictionary=dict(), parent_scope=ctx)
     for idx, var_name in enumerate(assigned_var_finder.assigned_vars):
-      c[StringAttr(var_name)]=block.args[idx+1]
+        c[StringAttr(var_name)] = block.args[idx + 1]
 
     # Now lets visit each operation in the loop body and build up the operations
     # which will be added to the block
     ops: List[Operation] = []
     for op in loop_stmt.body.blocks[0].ops:
-        pass # Needs to be completed!
+        pass  # Needs to be completed!
 
     # We need to yield out assigned variables at the end of the block
-    yield_stmt=generate_yield(c, assigned_var_finder.assigned_vars)
-    block.add_ops(ops+[yield_stmt])
-    body=Region()
+    yield_stmt = generate_yield(c, assigned_var_finder.assigned_vars)
+    block.add_ops(ops + [yield_stmt])
+    body = Region()
     body.add_block(block)
 
     # Build the for loop operation here
-    for_loop=None # Needs to be completed!
+    for_loop = None  # Needs to be completed!
 
     # From now on, whenever the code references any variable that was assigned
     # in the body of the loop we need to use the corresponding loop result
     for i, var_name in enumerate(assigned_var_finder.assigned_vars):
-      ctx[StringAttr(var_name)]=for_loop.results[i]
+        ctx[StringAttr(var_name)] = for_loop.results[i]
 
-    return start_expr+end_expr+[start_cast, end_cast, step_op, for_loop]
+    return start_expr + end_expr + [start_cast, end_cast, step_op, for_loop]
+
 
 def generate_yield(ctx: SSAValueCtx, assigned_vars) -> List[Operation]:
     """
       Generates a yield statement for exiting a block, this exposes
-      the updated variables to their origional values.
+      the updated variables to their original values.
       It is required because in SSA form when we update a
       variable it creates a new SSA element, and it is this
       element that then needs to be used as the program progresses.
@@ -248,26 +267,28 @@ def generate_yield(ctx: SSAValueCtx, assigned_vars) -> List[Operation]:
       it's FIR dialect which will explicitly allocate
       a variable and then store into it whenever it is updated.
     """
-    yield_list=[]
+    yield_list = []
     for var_name in assigned_vars:
         yield_list.append(ctx[StringAttr(var_name)])
 
-    return scf.Yield.get(*yield_list)
+    return scf.Yield(*yield_list)
+
 
 def translate_assign(ctx: SSAValueCtx,
-                      assign: tiny_py.Assign) -> List[Operation]:
+                     assign: tiny_py.Assign) -> List[Operation]:
     """
     Translates assignment
     """
     var_name = assign.var_name
     assert isinstance(var_name, StringAttr)
 
-    expr, ssa=translate_expr(ctx, assign.value.blocks[0].ops.first)
+    expr, ssa = translate_expr(ctx, assign.value.blocks[0].ops.first)
 
     # Always update the SSA context as it is this new SSA element that subsequent references
     # to the variable should reference
     ctx[var_name] = ssa
     return expr
+
 
 def translate_call_expr_stmt(ctx: SSAValueCtx,
                              call_expr: tiny_py.CallExpr, is_expr=False) -> List[Operation]:
@@ -284,59 +305,61 @@ def translate_call_expr_stmt(ctx: SSAValueCtx,
         op, arg = translate_expr(ctx, arg)
         if op is not None: ops += op
         args.append(arg)
-        arg_types.append(arg.typ)
+        arg_types.append(arg.type)
 
     # For now we limit the number of arguments to a function to one
     # Could easily remove this restriction but makes life easier with
     # the printf function
     assert len(args) == len(arg_types) == 1
 
-    name = call_expr.attributes["func"].data
+    name = call_expr.properties["func"].data
 
     if call_expr.builtin.data and name in builtin_function_name_mapping:
         # If this is a built in function and that name is in the mapping dictionary
         # then replace the name, for instance translating print to printf
-        name=builtin_function_name_mapping[name]
+        name = builtin_function_name_mapping[name]
 
     if name == "printf":
         # For printf if it is not a string then we need to store and pass the
         # C conversion string
-        conv_string=get_printf_conversion_string(args[0].typ)
+        conv_string = get_printf_conversion_string(args[0].type)
         if conv_string is not None:
-          conv_ops, conv_ssa = translate_string_into_global_and_get_element_ptr(conv_string)
-          args.insert(0, conv_ssa)
-          arg_types.insert(0, conv_ssa.typ)
-          ops+=conv_ops
+            conv_ops, conv_ssa = translate_string_into_global_and_get_element_ptr(conv_string)
+            args.insert(0, conv_ssa)
+            arg_types.insert(0, conv_ssa.type)
+            ops += conv_ops
 
-          if args[1].typ == f32:
-            # LLVM's printf only accepts doubles, therefore need to cast
-            # a single precision floating point to double
-            arg_cast=arith.ExtFOp.get(args[1], f64)
-            ops.append(arg_cast)
-            args[1]=arg_cast.results[0]
-            arg_types[1]=f64
+            if args[1].type == f32:
+                # LLVM's printf only accepts doubles, therefore need to cast
+                # a single precision floating point to double
+                arg_cast = arith.ExtFOp(args[1], f64)
+                ops.append(arg_cast)
+                args[1] = arg_cast.results[0]
+                arg_types[1] = f64
 
     if is_expr:
-        result_type=try_translate_type(call_expr.type)
-        call = func.Call.create(attributes={"callee": SymbolRefAttr(name)},
+        result_type = try_translate_type(call_expr.type)
+        call = func.Call.create(properties={"callee": SymbolRefAttr(name)},
                                 operands=args, result_types=[result_type])
     else:
-        call = func.Call.create(attributes={"callee": SymbolRefAttr(name)},
+        call = func.Call.create(properties={"callee": SymbolRefAttr(name)},
                                 operands=args, result_types=[])
     ops.append(call)
 
     if call_expr.builtin.data:
-      global_declarations.append(func.FuncOp.external(name, arg_types, []))
+        global_declarations.append(func.FuncOp.external(name, arg_types, []))
 
     return ops
 
+
 def get_printf_conversion_string(arg_type):
     if arg_type == f32 or arg_type == f64:
-      return "%f"
+        return "%f"
     elif arg_type == i32 or arg_type == i64:
-      return "%d"
+        return "%d"
     else:
-      return None
+        return None
+
 
 def translate_expr(ctx: SSAValueCtx,
                    op: Operation) -> Tuple[List[Operation], SSAValue]:
@@ -352,6 +375,7 @@ def translate_expr(ctx: SSAValueCtx,
     else:
         ops, ssa_value = res
         return ops, ssa_value
+
 
 def try_translate_expr(ctx: SSAValueCtx,
                        op: Operation) -> Optional[Tuple[List[Operation], SSAValue]]:
@@ -375,68 +399,72 @@ def try_translate_expr(ctx: SSAValueCtx,
 
     return None
 
+
 def translate_constant(op: tiny_py.Constant) -> Operation:
     """
     Translates a constant, literal, depending upon its type
     """
-    value = op.attributes["value"]
+    value = op.properties["value"]
 
     if isinstance(value, StringAttr):
         return translate_string_into_global_and_get_element_ptr(value.data)
 
     if isinstance(value, FloatAttr):
-        const= arith.Constant.create(attributes={"value": value},
-                                         result_types=[value.type])
+        const = arith.Constant.create(properties={"value": value},
+                                      result_types=[value.type])
         return [const], const.results[0]
 
     if isinstance(value, IntegerAttr):
-        const= arith.Constant.create(attributes={"value": value},
-                                         result_types=[value.typ])
+        const = arith.Constant.create(properties={"value": value},
+                                      result_types=[value.type])
         return [const], const.results[0]
 
     raise Exception(f"Could not translate `{op}' as a literal")
 
+
 def translate_string_into_global_and_get_element_ptr(string_val: str):
     global string_index
 
-    string_identifier="str"+str(string_index)
-    string_index+=1
+    string_identifier = "str" + str(string_index)
+    string_index += 1
 
-    value=StringAttr(string_val+"\n")
-    global_type=llvm.LLVMArrayType.from_size_and_type(len(value.data), IntegerType(8))
-    global_op=llvm.GlobalOp.get(global_type, string_identifier, "internal", 0, True, value=value, unnamed_addr=0)
+    value = StringAttr(string_val + "\n")
+    global_type = llvm.LLVMArrayType.from_size_and_type(len(value.data), IntegerType(8))
+    global_op = llvm.GlobalOp(global_type, string_identifier, "internal", 0, True, value=value, unnamed_addr=0)
     global_declarations.append(global_op)
 
-    global_lookup=llvm.AddressOfOp.get(string_identifier, llvm.LLVMPointerType.typed(global_type))
-    element_pointer=llvm.GEPOp.get(global_lookup.results[0], llvm.LLVMPointerType.typed(IntegerType(8)), [0,0])
+    global_lookup = llvm.AddressOfOp(string_identifier, llvm.LLVMPointerType.typed(global_type))
+    element_pointer = llvm.GEPOp(global_lookup.results[0], [0, 0], None, llvm.LLVMPointerType.typed(IntegerType(8)))
     return [global_lookup, element_pointer], element_pointer.results[0]
+
 
 def translate_binary_expr(ctx: SSAValueCtx,
                           op: Operation) -> Operation:
     """
     Translates a binary expression
     """
-    lhs, lhs_ssa=translate_expr(ctx, op.lhs.blocks[0].ops.first)
-    rhs, rhs_ssa=translate_expr(ctx, op.rhs.blocks[0].ops.first)
-    operand_type = lhs_ssa.typ
+    lhs, lhs_ssa = translate_expr(ctx, op.lhs.blocks[0].ops.first)
+    rhs, rhs_ssa = translate_expr(ctx, op.rhs.blocks[0].ops.first)
+    operand_type = lhs_ssa.type
     if op.op.data in binary_arith_op_matching:
         # We match here on the LHS type, for a more advanced coverage if the types are different
         # then we should convert the lower to the higher type, but we ignore that in our simple example
-        if isinstance(operand_type, IntegerType): index=0
+        if isinstance(operand_type, IntegerType): index = 0
         if isinstance(operand_type, Float16Type) or isinstance(operand_type, Float32Type
-                        ) or isinstance(operand_type, Float64Type): index=1
-        op_instance=binary_arith_op_matching[op.op.data][index]
-        assert op_instance is not None, "Operation "+op.op.data+" not implemented for type"
-        bin_op=op_instance.get(lhs_ssa, rhs_ssa)
+                                                               ) or isinstance(operand_type, Float64Type): index = 1
+        op_instance = binary_arith_op_matching[op.op.data][index]
+        assert op_instance is not None, "Operation " + op.op.data + " not implemented for type"
+        bin_op = op_instance(lhs_ssa, rhs_ssa)
         return [bin_op], bin_op.results[0]
     else:
         raise Exception(f"Could not translate operation `{op.op.data}' as it is unknown")
 
-@dataclass
+
+@dataclass(frozen=True)
 class LowerTinyPyToStandard(ModulePass):
+    name = 'tiny-py-to-standard'
 
-  name = 'tiny-py-to-standard'
-
-  def apply(self, ctx: MLContext, input_module: ModuleOp):
-      res_module = translate_program(input_module)
-      res_module.regions[0].move_blocks(input_module.regions[0])
+    def apply(self, ctx: MLContext, input_module: ModuleOp):
+        res_module = translate_program(input_module)
+        res_module.regions[0].move_blocks(input_module.regions[0])
+        input_module.regions[0].detach_block(0)

--- a/practical/src/tools/tinypy-opt
+++ b/practical/src/tools/tinypy-opt
@@ -3,7 +3,7 @@
 import argparse
 import ast
 from io import IOBase
-from xdsl.ir import MLContext
+from xdsl.context import MLContext
 from xdsl.dialects.builtin import ModuleOp
 from tiny_py_to_standard import LowerTinyPyToStandard
 from for_to_parallel import ConvertForToParallel
@@ -12,23 +12,24 @@ from util.semantic_error import SemanticError
 from typing import Callable, Dict, List
 from xdsl.xdsl_opt_main import xDSLOptMain
 
+
 class PsyOptMain(xDSLOptMain):
 
     def register_all_passes(self):
-      super().register_all_passes()
-      self.register_pass(LowerTinyPyToStandard)
-      self.register_pass(ConvertForToParallel)
+        super().register_all_passes()
+        self.register_pass("tiny-py-to-standard", lambda: LowerTinyPyToStandard)
+        self.register_pass("for-to-parallel", lambda: ConvertForToParallel)
 
     def register_all_targets(self):
         super().register_all_targets()
 
     def setup_pipeline(self):
-      super().setup_pipeline()
+        super().setup_pipeline()
 
     def register_all_dialects(self):
         super().register_all_dialects()
         """Register all dialects that can be used."""
-        self.ctx.register_dialect(tinyPyIR)
+        self.ctx.register_dialect("tiny_py", lambda: tinyPyIR)
 
     @staticmethod
     def get_passes_as_dict(
@@ -64,17 +65,13 @@ def __main__():
     psy_main = PsyOptMain()
 
     try:
-        module = psy_main.parse_input()
-        psy_main.apply_passes(module)
+        psy_main.run()
     except SyntaxError as e:
         print(e.get_message())
         exit(0)
     except SemanticError as e:
         print("Semantic error: %s" % str(e))
         exit(0)
-
-    contents = psy_main.output_resulting_program(module)
-    psy_main.print_to_output_stream(contents)
 
 
 if __name__ == "__main__":

--- a/practical/three/exercise_three.md
+++ b/practical/three/exercise_three.md
@@ -41,7 +41,7 @@ The _parallel_ operation represents a parallel for loop, and there are existing 
 
 Of course, one way of leveraging the _parallel_ operation would be to edit our _tiny_py_to_standard_ transformation which lowers from tiny py down to the standard dialects, issuing _parallel_ instead of _for_. However, let's assume that we do not want to edit that and instead wish to apply an optimisation/transformation pass on the resulting IR that comes out of _tiny_py_to_standard_ in order to convert our sequential loop into a parallel one. 
 
-If you take a look in [tinypy-opt](https://github.com/xdslproject/training-intro/blob/main/practical/src/tools/tinypy-opt) tool (which is in _src/tools_ from the _practical_ directory) you will see at line 17 the _register_all_passes_ function which is registering possible transformations that can be performed on the IR. The second of these, _ConvertForToParallel_ is the transformation that we will be working with in this exercise and have already started off for you.
+If you take a look in [tinypy-opt](https://github.com/xdslproject/training-intro/blob/main/practical/src/tools/tinypy-opt) tool (which is in _src/tools_ from the _practical_ directory) you will see at line 18 the _register_all_passes_ function which is registering possible transformations that can be performed on the IR. The second of these, _ConvertForToParallel_ is the transformation that we will be working with in this exercise and have already started off for you.
 
 This transformation can be found in [src/for_to_parallel.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/for_to_parallel.py) and the transformation entry point is defined at the bottom of the file by the class _ConvertForToParallel_, where the _name_ field defines the name of the transformation as provided to _tinypy_opt_.
 
@@ -71,11 +71,10 @@ The rewrite pattern defined above, that we will be working with in a moment, is 
 We now want to replace the _for_ operation in the _scf_ dialect with a _parallel_ operation, based on what we generated for exercise two, you might assume that this would look something like the following:
 
 ```
-%7 = "scf.parallel"(%4, %5, %6, %0) ({
-^0(%8 : index, %9 : f32):
-  %10 = "arith.addf"(%9, %1) : (f32, f32) -> f32
-  "scf.yield"(%10) : (f32) -> ()
-}) : (index, index, index, f32) -> f32
+%7 = scf.parallel %8 = %4 to %5 step %6 iter_args(%9 = %0) -> (f32) {
+   %10 = arith.addf %9, %1 : f32
+   scf.yield %10 : f32
+}
 ```
 
 However, unfortunately it is not quite this easy! You can see from the IR above that we are updating the left hand side of the _addf_ operation on each loop iteration, effectively undertaking a sum reduction overall. Because of this loop carried dependency, this reduction must be wrapped in a _reduce_ operation which instructs MLIR to implement this as a reduction when it lowers to the _omp_, _vector_, or _gpu_ dialects.
@@ -83,15 +82,15 @@ However, unfortunately it is not quite this easy! You can see from the IR above 
 Instead, the following is what we are after, where it can be seen that there is now only one argument to the top level block (which is the loop iteration count), and within this block sits the _reduction_ operation from the _scf_ dialect. This operation must contain one block with the left hand and right hand sides of the operation that is being reduced, in this case _addf_, and the result of this is returned out via the _reduce.return_ operation.
 
 ```
-%7 = "scf.parallel"(%4, %5, %6, %0) ({
-^0(%8 : index):
-  "scf.reduce"(%1) ({
-    ^1(%lhs : f32, %rhs : f32):
-      %11 = "arith.addf"(%lhs, %rhs) : (f32, f32) -> f32
-      "scf.reduce.return"(%11) : (f32) -> ()
-    }) : (f32) -> ()
-  "scf.yield"() : () -> ()
-}) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
+%7 = "scf.parallel"(%4, %5, %6, %0) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> ({
+    ^0(%8 : index):
+      "scf.reduce"(%1) ({
+      ^1(%9 : f32, %10 : f32):
+        %11 = arith.addf %9, %10 : f32
+        "scf.reduce.return"(%11) : (f32) -> ()
+      }) : (f32) -> ()
+      scf.yield
+    }) : (index, index, index, f32) -> f32
 ```
 
 If we look at the first line, `"%7 =scf.parallel"(%4, %5, %6, %0)` in the above snippet, the first three arguments are the loop lower bounds, upper bounds, and step size respectively. All others, here _%0_ are values provided as arguments and MLIR will use each of these as the left hand side argument (_lhs_) of the _reduce_ operations. Therefore the number of value provided arguments, in this case 1, must match the number of reductions. This is similar for results of the _parallel_ operation, where the result of the _ith_ _reduce_ operation is mapped to the _ith_ overall result. Lastly, the argument provided in `"scf.reduce"(%1)` is set as the right hand side (_rhs_) of the subsequent operation.
@@ -109,58 +108,59 @@ class ApplyForToParallelRewriter(RewritePattern):
 
         # First we get the body of the for loop and detach it (as will attack to the
         # parallel loop when we create it)
-        loop_body=for_loop.body.blocks[0]
+        loop_body = for_loop.body.blocks[0]
         for_loop.body.detach_block(0)
+        
         # Now get the arguments to the yield at the end of the for loop and the arguments
         # to the loop block too
-        yielded_args=list(loop_body.ops.last.arguments)
-        block_args=list(loop_body.args)
+        yielded_args = list(loop_body.ops.last.arguments)
+        block_args = list(loop_body.args)
 
-        ops_to_add=[]
-        for op in loop_body.ops:          
-          # We go through each operation in the loop body and see if it is one that needs
-          # a reduction operation applied to it
-          if op.name in matched_operations.keys():
-            # We need to find if it is the LHS or RHS that is based upon the argument to the block
-            # if it is neither then ignore this as it is not going to be updated from one iteration
-            # to the next so no need to wrap in a reduction
-            if isinstance(op.lhs, BlockArgument):
-              block_arg_op=op.lhs
-              other_arg=op.rhs
-            elif isinstance(op.rhs, BlockArgument):
-              block_arg_op=op.rhs
-              other_arg=op.lhs
-            else:
-              continue
+        ops_to_add = []
+        for op in loop_body.ops:
+            # We go through each operation in the loop body and see if it is one that needs
+            # a reduction operation applied to it
+            if op.name in matched_operations.keys():
+                # We need to find if it is the LHS or RHS that is based upon the argument to the block
+                # if it is neither then ignore this as it is not going to be updated from one iteration
+                # to the next so no need to wrap in a reduction
+                if isinstance(op.lhs, BlockArgument):
+                    block_arg_op = op.lhs
+                    other_arg = op.rhs
+                elif isinstance(op.rhs, BlockArgument):
+                    block_arg_op = op.rhs
+                    other_arg = op.lhs
+                else:
+                    continue
 
-            # Now detach op from the body and remove from those arguments yielded
-            # and arguments to the top level block
-            op.detach()
-            yielded_args.remove(op.results[0])
-            block_args.remove(block_arg_op)
+                # Now detach op from the body and remove from those arguments yielded
+                # and arguments to the top level block
+                op.detach()
+                yielded_args.remove(op.results[0])
+                block_args.remove(block_arg_op)
 
-            # Create a new block for this reduction operation which has the type of
-            # operation LHS and RHS present
-            block_arg_types=[] # Needs to be completed!
-            block = Block(arg_types=block_arg_types)
+                # Create a new block for this reduction operation which has the type of
+                # operation LHS and RHS present
+                block_arg_types = []  # Needs to be completed!
+                block = Block(arg_types=block_arg_types)
 
-            # Retrieve the dialect operation to instantiate
-            op_instance=matched_operations[op.name]
-            assert op_instance is not None
+                # Retrieve the dialect operation to instantiate
+                op_instance = matched_operations[op.name]
+                assert op_instance is not None
 
-            # Instantiate the dialect operation and create a reduce return operation
-            # that will return the result, then add these operations to the block
-            new_op=op_instance.get(block.args[0], block.args[1])
-            reduce_result=None # Needs to be completed!
-            block.add_ops([new_op, reduce_result])
+                # Instantiate the dialect operation and create a reduce return operation
+                # that will return the result, then add these operations to the block
+                new_op = op_instance(block.args[0], block.args[1])
+                reduce_result = None  # Needs to be completed!
+                block.add_ops([new_op, reduce_result])
 
-            # Create the reduce operation and add to the top level block
-            reduce_op=None # Needs to be completed!
-            #ops_to_add.append(reduce_op)
+                # Create the reduce operation and add to the top level block
+                reduce_op = None  # Needs to be completed!
+                ops_to_add.append(reduce_op)
 
         # Create a new top level block which will have far fewer arguments
         # as none of the reduction arguments are now present here
-        new_block=Block(arg_types=[arg.typ for arg in block_args])
+        new_block = Block(arg_types=[arg.type for arg in block_args])
         new_block.add_ops(ops_to_add)
 
         for op in loop_body.ops:
@@ -169,23 +169,23 @@ class ApplyForToParallelRewriter(RewritePattern):
 
         # We have a yield at the end of the block which yields non reduction
         # arguments
-        new_yield=scf.Yield.get(*yielded_args)
+        new_yield = scf.Yield(*yielded_args)
         new_block.erase_op(new_block.ops.last)
         new_block.add_op(new_yield)
 
         # Create our parallel operation and replace the for loop with this
-        parallel_loop=None # Needs to be completed!         
+        parallel_loop = None  # Needs to be completed!
 ```
 
 The method _match_and_rewrite_ defined as `def match_and_rewrite(self, for_loop: scf.For, rewriter: PatternRewriter)` will be called whenever the IR walker encounters a node which is of type _scf.For_. This is the argument _for_loop_ to the method, which we can then manipulate as required by the transformation
 
-If we look at line 55 of [src/for_to_parallel.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/for_to_parallel.py), which is `block_arg_types=[] # Needs to be completed!`, we need to provide the two types of the left and right hand sides as arguments to the block. These are _block_arg_op.typ_ and _other_arg.typ_ respectively, and each should be a member of the list (with a comma separating them).
+If we look at line 57 of [src/for_to_parallel.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/for_to_parallel.py), which is `block_arg_types = []  # Needs to be completed!`, we need to provide the two types of the left and right hand sides as arguments to the block. These are _block_arg_op.type_ and _other_arg.type_ respectively, and each should be a member of the list (with a comma separating them).
 
-At line 65, which is `reduce_result=None # Needs to be completed!` we need to create the _reduce.return_ operation which will return the result of the calculation's operation. We can create this by calling the _get_ method on _scf.ReduceReturnOp_, with _new_op.results[0]_ as the argument (this provides the SSA result of the _new_op_ operation that we created at the line above. 
+At line 67, which is `reduce_result = None  # Needs to be completed!` we need to create the _reduce.return_ operation which will return the result of the calculation's operation. We can create this by calling the constructor of _scf.ReduceReturnOp_, with _new_op.results[0]_ as the argument (this provides the SSA result of the _new_op_ operation that we created at the line above. 
 
-At line 69, `reduce_op=None # Needs to be completed!`, we need to create the overall _reduce_ operation. This is done by calling the _get_ method on _scf.ReduceOp_, and there are two arguments needed here. The first is the operand, _other_arg_, provided to this (_%1_ in our IR example of the previous section) and the second is the block, which is the _block_ variable in the code, that will comprise this operation.
+At line 71, `reduce_op = None  # Needs to be completed!`, we need to create the overall _reduce_ operation. This is done by calling the constructor of _scf.ReduceOp_, and there are two arguments needed here. The first is the operand, _other_arg_, provided to this (_%1_ in our IR example of the previous section) and the second is the block, which is the _block_ variable in the code, that will comprise this operation.
 
-Now we have done this we need to create the parallel loop operation itself, which is line 88, `parallel_loop=None # Needs to be completed!`. Again, we will be calling the _get_ method but this time on _scf.ParallelOp_. We can directly reuse the loop bounds and step from the for loop, _for_loop.lb_, _for_loop.ub_, and _for_loop.step_ as the first three arguments but crucially each of these needs to be wrapped in a list (so it will be [_for_loop.lb_]) - we will explain why that is the case a little later on. The _new_block_ variable is our block, that is the fourth argument and again must be wrapped in a list, and the fifth argument is the list of SSA argument values provided (in the IR example above this will be _%0_) and is _for_loop.iter_args_ which is already a list so need not be wrapped in one.
+Now we have done this we need to create the parallel loop operation itself, which is line 90, `parallel_loop = None  # Needs to be completed!`. Again, we will be calling the constructor but this time for _scf.ParallelOp_. We can directly reuse the loop bounds and step from the for loop, _for_loop.lb_, _for_loop.ub_, and _for_loop.step_ as the first three arguments but crucially each of these needs to be wrapped in a list (so it will be [_for_loop.lb_]) - we will explain why that is the case a little later on. The _new_block_ variable is our block, that is the fourth argument and again must be wrapped in a list, and the fifth argument is the list of SSA argument values provided (in the IR example above this will be _%0_) and is _for_loop.iter_args_ which is already a list so need not be wrapped in one.
 
 We are almost there, the last step is to instruct xDSL to replace the for loop with the new parallel loop. As the last line of this _match_and_rewrite_ method, just after you created the _parallel_ operation, you should add `rewriter.replace_matched_op(parallel_loop)`.
 
@@ -199,11 +199,11 @@ A lot of the work being done here in the transformation is in extracting the arg
 There are some things worth highlighting in the IR and rewrite pass that we have skipped over so far. Firstly, we passed the parallel loop's lower and upper bounds along with the step in a list. This is because a _parallel_ operation can represent a nested loop and the below IR example illustrates a parallel loop operating over a nested loop, with _%4_ being the lower bounds of the top loop and _%5_ the lower bounds of the inner loop. The upper bounds and step values follow a similar logic. You can see that the block now has two index argument, representing the current iteration of both the inner and outer loops. MLIR will transform this as it feels most appropriate, for instance with the _openmp_ lowering it will likely apply the _collapse_ clause.
 
 ```
-%7 = "scf.parallel"(%4, %5, %6, %7, %8, %9) ({
+%7 = "scf.parallel"(%4, %5, %6, %7, %8, %9) <{"operand_segment_sizes" = array<i32: 2, 2, 2, 0>}> ({
   ^0(%10 : index, %11 : index):
   ...
-  "scf.yield"() : () -> ()
-}) {"operand_segment_sizes" = array<i32: 2, 2, 2, 0>} : (index, index, index, index, index, index) -> ()
+  scf.yield
+}) : (index, index, index, index, index, index) -> ()
 ```
 
 You can see in the above IR that we have _operand_segment_sizes_ provided as an argument to the operation. This is required for _varadic_ operands, which are operands which can have any size. Here the attribute is informing the operation that it is two lower bound operands, two upper bound operands, and two step operands but no SSA value arguments to be passed in.
@@ -219,35 +219,34 @@ user@login01:~$ tinypy-opt output.mlir -p tiny-py-to-standard,for-to-parallel
 The following is the IR outputted from these two transformations, you can see the _parallel_, _reduce_, and _reduce.return_ operations that we have added into our transformation in this section. The rest of the IR is the same as that generated in exercise two, and that is a major benefit of using _parallel_ because we can parallelise a loop without requiring extensive IR changes elsewhere.
 
 ```
-"builtin.module"() ({
-  "func.func"() ({
-    %0 = "arith.constant"() {"value" = 0.0 : f32} : () -> f32
-    %1 = "arith.constant"() {"value" = 88.2 : f32} : () -> f32
-    %2 = "arith.constant"() {"value" = 0 : i32} : () -> i32
-    %3 = "arith.constant"() {"value" = 100000 : i32} : () -> i32
-    %4 = "arith.index_cast"(%2) : (i32) -> index
-    %5 = "arith.index_cast"(%3) : (i32) -> index
-    %6 = "arith.constant"() {"value" = 1 : index} : () -> index
-    %7 = "scf.parallel"(%4, %5, %6, %0) ({
+builtin.module {
+  func.func @main() {
+    %0 = arith.constant 0.000000e+00 : f32
+    %1 = arith.constant 8.820000e+01 : f32
+    %2 = arith.constant 0 : i32
+    %3 = arith.constant 100000 : i32
+    %4 = arith.index_cast %2 : i32 to index
+    %5 = arith.index_cast %3 : i32 to index
+    %6 = arith.constant 1 : index
+    %7 = "scf.parallel"(%4, %5, %6, %0) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> ({
     ^0(%8 : index):
       "scf.reduce"(%1) ({
       ^1(%9 : f32, %10 : f32):
-        %11 = "arith.addf"(%9, %10) : (f32, f32) -> f32
+        %11 = arith.addf %9, %10 : f32
         "scf.reduce.return"(%11) : (f32) -> ()
       }) : (f32) -> ()
-      "scf.yield"() : () -> ()
-    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
-    %12 = "llvm.mlir.addressof"() {"global_name" = @str0} : () -> !llvm.ptr<!llvm.array<3 x i8>>
-    %13 = "llvm.getelementptr"(%12) {"rawConstantIndices" = array<i32: 0, 0>} : (!llvm.ptr<!llvm.array<3 x i8>>) -> !llvm.ptr<i8>
-    %14 = "arith.extf"(%7) : (f32) -> f64
-    "func.call"(%13, %14) {"callee" = @printf} : (!llvm.ptr<i8>, f64) -> ()
-    "func.return"() : () -> ()
-  }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "public"} : () -> ()
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<3 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "%f\n", "unnamed_addr" = 0 : i64} : () -> ()
-  "func.func"() ({
-  }) {"sym_name" = "printf", "function_type" = (!llvm.ptr<i8>, f64) -> (), "sym_visibility" = "private"} : () -> ()
-}) : () -> ()
+      scf.yield
+    }) : (index, index, index, f32) -> f32
+    %12 = "llvm.mlir.addressof"() <{"global_name" = @str0}> : () -> !llvm.ptr<!llvm.array<3 x i8>>
+    %13 = "llvm.getelementptr"(%12) <{"rawConstantIndices" = array<i32: 0, 0>}> : (!llvm.ptr<!llvm.array<3 x i8>>) -> !llvm.ptr<i8>
+    %14 = arith.extf %7 : f32 to f64
+    func.call @printf(%13, %14) : (!llvm.ptr<i8>, f64) -> ()
+    func.return
+  }
+  "llvm.mlir.global"() <{"global_type" = !llvm.array<3 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "%f\n", "unnamed_addr" = 0 : i64}> ({
+  }) : () -> ()
+  func.func private @printf(!llvm.ptr<i8>, f64) -> ()
+}
 ```
 
 ## Compile and run

--- a/practical/three/sample_solutions/for_to_parallel.py
+++ b/practical/three/sample_solutions/for_to_parallel.py
@@ -1,5 +1,6 @@
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, SSAValue, Region, Block, MLContext, BlockArgument
+from xdsl.ir import Operation, SSAValue, Region, Block, BlockArgument
+from xdsl.context import MLContext
 from xdsl.dialects import scf, arith
 from dataclasses import dataclass
 from xdsl.passes import ModulePass
@@ -7,7 +8,8 @@ from xdsl.pattern_rewriter import (GreedyRewritePatternApplier,
                                    PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, op_type_rewrite_pattern)
 
-matched_operations={"arith.addf": arith.Addf, "arith.addi": arith.Addi}
+matched_operations = {"arith.addf": arith.Addf, "arith.addi": arith.Addi}
+
 
 class ApplyForToParallelRewriter(RewritePattern):
 
@@ -20,58 +22,59 @@ class ApplyForToParallelRewriter(RewritePattern):
         """
         # First we get the body of the for loop and detach it (as will attack to the
         # parallel loop when we create it)
-        loop_body=for_loop.body.blocks[0]
+        loop_body = for_loop.body.blocks[0]
         for_loop.body.detach_block(0)
+
         # Now get the arguments to the yield at the end of the for loop and the arguments
         # to the loop block too
-        yielded_args=list(loop_body.ops.last.arguments)
-        block_args=list(loop_body.args)
+        yielded_args = list(loop_body.ops.last.arguments)
+        block_args = list(loop_body.args)
 
-        ops_to_add=[]
+        ops_to_add = []
         for op in loop_body.ops:
-          # We go through each operation in the loop body and see if it is one that needs
-          # a reduction operation applied to it
-          if op.name in matched_operations.keys():
-            # We need to find if it is the LHS or RHS that is based upon the argument to the block
-            # if it is neither then ignore this as it is not going to be updated from one iteration
-            # to the next so no need to wrap in a reduction
-            if isinstance(op.lhs, BlockArgument):
-              block_arg_op=op.lhs
-              other_arg=op.rhs
-            elif isinstance(op.rhs, BlockArgument):
-              block_arg_op=op.rhs
-              other_arg=op.lhs
-            else:
-              continue
+            # We go through each operation in the loop body and see if it is one that needs
+            # a reduction operation applied to it
+            if op.name in matched_operations.keys():
+                # We need to find if it is the LHS or RHS that is based upon the argument to the block
+                # if it is neither then ignore this as it is not going to be updated from one iteration
+                # to the next so no need to wrap in a reduction
+                if isinstance(op.lhs, BlockArgument):
+                    block_arg_op = op.lhs
+                    other_arg = op.rhs
+                elif isinstance(op.rhs, BlockArgument):
+                    block_arg_op = op.rhs
+                    other_arg = op.lhs
+                else:
+                    continue
 
-            # Now detach op from the body and remove from those arguments yielded
-            # and arguments to the top level block
-            op.detach()
-            yielded_args.remove(op.results[0])
-            block_args.remove(block_arg_op)
+                # Now detach op from the body and remove from those arguments yielded
+                # and arguments to the top level block
+                op.detach()
+                yielded_args.remove(op.results[0])
+                block_args.remove(block_arg_op)
 
-            # Create a new block for this reduction operation which has the type of
-            # operation LHS and RHS present
-            block_arg_types=[block_arg_op.typ, other_arg.typ]
-            block = Block(arg_types=block_arg_types)
+                # Create a new block for this reduction operation which has the type of
+                # operation LHS and RHS present
+                block_arg_types = [block_arg_op.type, other_arg.type]
+                block = Block(arg_types=block_arg_types)
 
-            # Retrieve the dialect operation to instantiate
-            op_instance=matched_operations[op.name]
-            assert op_instance is not None
+                # Retrieve the dialect operation to instantiate
+                op_instance = matched_operations[op.name]
+                assert op_instance is not None
 
-            # Instantiate the dialect operation and create a reduce return operation
-            # that will return the result, then add these operations to the block
-            new_op=op_instance.get(block.args[0], block.args[1])
-            reduce_result=scf.ReduceReturnOp.get(new_op.results[0])
-            block.add_ops([new_op, reduce_result])
+                # Instantiate the dialect operation and create a reduce return operation
+                # that will return the result, then add these operations to the block
+                new_op = op_instance(block.args[0], block.args[1])
+                reduce_result = scf.ReduceReturnOp(new_op.results[0])
+                block.add_ops([new_op, reduce_result])
 
-            # Create the reduce operation and add to the top level block
-            reduce_op=scf.ReduceOp.get(other_arg, block)
-            ops_to_add.append(reduce_op)
+                # Create the reduce operation and add to the top level block
+                reduce_op = scf.ReduceOp(other_arg, block)
+                ops_to_add.append(reduce_op)
 
         # Create a new top level block which will have far fewer arguments
         # as none of the reduction arguments are now present here
-        new_block=Block(arg_types=[arg.typ for arg in block_args])
+        new_block = Block(arg_types=[arg.type for arg in block_args])
         new_block.add_ops(ops_to_add)
 
         for op in loop_body.ops:
@@ -80,23 +83,30 @@ class ApplyForToParallelRewriter(RewritePattern):
 
         # We have a yield at the end of the block which yields non reduction
         # arguments
-        new_yield=scf.Yield.get(*yielded_args)
+        new_yield = scf.Yield(*yielded_args)
         new_block.erase_op(new_block.ops.last)
         new_block.add_op(new_yield)
 
         # Create our parallel operation and replace the for loop with this
-        parallel_loop=scf.ParallelOp.get([for_loop.lb], [for_loop.ub], [for_loop.step], [new_block], for_loop.iter_args)
+        parallel_loop = scf.ParallelOp(
+            [for_loop.lb],
+            [for_loop.ub],
+            [for_loop.step],
+            [new_block],
+            for_loop.iter_args
+        )
+
         rewriter.replace_matched_op(parallel_loop)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConvertForToParallel(ModulePass):
-  """
-  This is the entry point for the transformation pass which will then apply the rewriter
-  """
-  name = 'for-to-parallel'
+    """
+    This is the entry point for the transformation pass which will then apply the rewriter
+    """
+    name = 'for-to-parallel'
 
-  def apply(self, ctx: MLContext, input_module: ModuleOp):
-    applyRewriter=ApplyForToParallelRewriter()
-    walker = PatternRewriteWalker(GreedyRewritePatternApplier([applyRewriter]), apply_recursively=False)
-    walker.rewrite_module(input_module)
+    def apply(self, ctx: MLContext, input_module: ModuleOp):
+        apply_rewriter = ApplyForToParallelRewriter()
+        walker = PatternRewriteWalker(GreedyRewritePatternApplier([apply_rewriter]), apply_recursively=False)
+        walker.rewrite_module(input_module)

--- a/practical/two/exercise_two.md
+++ b/practical/two/exercise_two.md
@@ -46,21 +46,21 @@ user@login01:~$ python3.10 ex_two.py
 The output will look like the following, and you can also find it in the newly created _output.mlir_ file.
 
 ```
-"builtin.module"() ({
+builtin.module {
   "tiny_py.module"() ({
-    "tiny_py.function"() ({
-      "tiny_py.assign"() ({
-        "tiny_py.constant"() {"value" = 0.0 : f32} : () -> ()
-      }) {"var_name" = "val"} : () -> ()
-      "tiny_py.assign"() ({
-        "tiny_py.constant"() {"value" = 88.2 : f32} : () -> ()
-      }) {"var_name" = "add_val"} : () -> ()
-      "tiny_py.call_expr"() ({
-        "tiny_py.var"() {"variable" = "val"} : () -> ()
-      }) {"func" = "print", "type" = !empty, "builtin" = #bool<"True">} : () -> ()
-    }) {"fn_name" = "ex_two", "return_var" = !empty, "args" = []} : () -> ()
+    "tiny_py.function"() <{"fn_name" = "ex_two", "return_var" = !tiny_py.empty, "args" = []}> ({
+      "tiny_py.assign"() <{"var_name" = "val"}> ({
+        "tiny_py.constant"() <{"value" = 0.000000e+00 : f32}> : () -> ()
+      }) : () -> ()
+      "tiny_py.assign"() <{"var_name" = "add_val"}> ({
+        "tiny_py.constant"() <{"value" = 8.820000e+01 : f32}> : () -> ()
+      }) : () -> ()
+      "tiny_py.call_expr"() <{"func" = "print", "type" = !tiny_py.empty, "builtin" = #tiny_py.bool"True"}> ({
+        "tiny_py.var"() <{"variable" = "val"}> : () -> ()
+      }) : () -> ()
+    }) : () -> ()
   }) : () -> ()
-}) : () -> ()
+}
 ```
 
 As you can see, we have the variable declarations and print statement at the end, but the loop and everything within it is missing. Don't worry, this is intentional and because our compiler is currently unaware of loops. The main purpose of this exercise is to add in support for handling loops. 
@@ -69,36 +69,41 @@ As you can see, we have the variable declarations and print statement at the end
 
 ### Supporting loops in the tiny py dialect
 
-The first step is to enhance the _tiny_py_ dialect so that it is capable of representing a loop. Open up the _tiny_py.py_ file that is in _src/dialects_ and at line 125 you will see we have started the _Loop_ class. The _get_ function has been completed, as has the name, but we need to fill in the fields that will comprise the operation's fields (its operands, attributes, regions and results). 
+The first step is to enhance the _tiny_py_ dialect so that it is capable of representing a loop. Open up the _tiny_py.py_ file that is in _src/dialects_ and at line 125 you will see we have started the _Loop_ class. The constructor has been completed, as has the name, but we need to fill in the fields that will comprise the operation's fields (its operands, attributes, regions and results). 
 
-Let's take a quick look at the code so far in this function (omitting the comments that are in the code to keep it a little shorter here) to explain what it is doing. This is below, and the _irdl_op_definition_ decorator annotates that this Operation follows the IRDL definition that we covered in the second lecture. The name of the operation is defined and the _get_ method creates an instance of this based upon the arguments provided. You can see that to create the operation a string (the variable name) and three operations are passed in. These comprise the four members of the operation, and it is these we need to add a definition for. 
+Let's take a quick look at the code so far in this function (omitting the comments that are in the code to keep it a little shorter here) to explain what it is doing. This is below, and the _irdl_op_definition_ decorator annotates that this Operation follows the IRDL definition that we covered in the second lecture. The name of the operation is defined and the constructor creates an instance of this based upon the arguments provided. You can see that to create the operation a string (the variable name) and three operations are passed in. These comprise the four members of the operation, and it is these we need to add a definition for. 
 
 ```Python
 @irdl_op_definition
 class Loop(IRDLOperation):
     name = "tiny_py.loop"
+    traits = frozenset([NoTerminator()])
 
-    @staticmethod
-    def get(variable: str | StringAttr,
-            from_expr: Operation,
-            to_expr: Operation,
-            body: List[Operation],
-            verify_op: bool = True) -> If:
+    def __init__(self,
+                 variable: str | StringAttr,
+                 from_expr: Operation,
+                 to_expr: Operation,
+                 body: List[Operation],
+                 verify_op: bool = True):
+
         if isinstance(variable, str):
             # If variable is a string then wrap it in StringAttr
-            variable=StringAttr(variable)
+            variable = StringAttr(variable)
 
-        res = Loop.build(attributes={"variable": variable}, regions=[Region([Block([from_expr])]),
-            Region([Block([to_expr])]), Region([Block(body)])])
+        super().__init__(properties={"variable": variable},
+                         regions=[
+                             Region([Block([from_expr])]),
+                             Region([Block([to_expr])]),
+                             Region([Block(body)])
+                         ])
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
 ```
 
 You can see that we construct a string attribute (_StringAttr_) if the _variable_ is a raw string, and then these four fields are provided to the _Loop.build_ method call, where the _variable_ attribute is set and three regions specified. As we discussed in lecture one, each region contains a list of blocks which itself contains a list of operations. Hence we are constructing _Regions_ from a list of _Blocks_ and these from a list of operations. You can see from the method signature that _body_ is already a list of operations, and hence it is not wrapped in a list here.
 
-There should be four fields, _variable_ which is an attribute of type _StringAttr_, and then three regions which are called _from_expr_, _to_expr_, and _body_. To understand the format these should follow then you can look at other operator definitions in the dialect, for instance _Var_ defines a string attribute member and _lhs_ and _rhs_ in _BinaryOperation_ are regions.
+There should be four fields, _variable_ which is an property of type _StringAttr_, and then three regions which are called _from_expr_, _to_expr_, and _body_. To understand the format these should follow then you can look at other operator definitions in the dialect, for instance _Var_ defines a string property member and _lhs_ and _rhs_ in _BinaryOperation_ are regions.
 
 >**Not sure or having problems?**
 > Please feel free to ask if there is anything you are unsure about, or you can check the [sample solution](https://github.com/xdslproject/training-intro/blob/main/practical/two/sample_solutions/tiny_py.py)
@@ -121,7 +126,7 @@ def visit_For(self, node):
 
 In this code each member comprising the body of the loop is visited and the resulting operations are stored in the _contents_ list. We are then processing the loop bounds and for the purposes of this tutorial are simplifying things quite a bit here where we extract the lower and upper bounds from the Python _Range_ and set these as _expr_from_ and _expr_to_ respectively.
 
-Currently this _visit_For_ function returns _None_ and instead we need to construct the _tiny_py_ dialect's _Loop_ operation. To do this you will use the _Loop.get_ function, providing the name of the loop variable (which you can obtain via _node.target.id_ and _expr_from_, _expr_to_, and _contents_ as the region arguments.
+Currently this _visit_For_ function returns _None_ and instead we need to construct the _tiny_py_ dialect's _Loop_ operation. To do this you will use the _Loop_ constructor, providing the name of the loop variable (which you can obtain via _node.target.id_ and _expr_from_, _expr_to_, and _contents_ as the region arguments.
 
 >**Not sure or having problems?**
 > Please feel free to ask if there is anything you are unsure about, or you can check the [sample solution](https://github.com/xdslproject/training-intro/blob/main/practical/two/sample_solutions/python_compiler.py)
@@ -137,34 +142,34 @@ user@login01:~$ python3.10 ex_two.py
 You should see the output below where, as you can see, the loop is now represented containing the _variable_ string as an attribute and the three regions (each of these are between the { } braces).
 
 ```
-"builtin.module"() ({
+builtin.module {
   "tiny_py.module"() ({
-    "tiny_py.function"() ({
-      "tiny_py.assign"() ({
-        "tiny_py.constant"() {"value" = 0.0 : f32} : () -> ()
-      }) {"var_name" = "val"} : () -> ()
-      "tiny_py.assign"() ({
-        "tiny_py.constant"() {"value" = 88.2 : f32} : () -> ()
-      }) {"var_name" = "add_val"} : () -> ()
-      "tiny_py.loop"() ({
-        "tiny_py.constant"() {"value" = 0 : i32} : () -> ()
+    "tiny_py.function"() <{"fn_name" = "ex_two", "return_var" = !tiny_py.empty, "args" = []}> ({
+      "tiny_py.assign"() <{"var_name" = "val"}> ({
+        "tiny_py.constant"() <{"value" = 0.000000e+00 : f32}> : () -> ()
+      }) : () -> ()
+      "tiny_py.assign"() <{"var_name" = "add_val"}> ({
+        "tiny_py.constant"() <{"value" = 8.820000e+01 : f32}> : () -> ()
+      }) : () -> ()
+      "tiny_py.loop"() <{"variable" = "a"}> ({
+        "tiny_py.constant"() <{"value" = 0 : i32}> : () -> ()
       }, {
-        "tiny_py.constant"() {"value" = 100000 : i32} : () -> ()
+        "tiny_py.constant"() <{"value" = 100000 : i32}> : () -> ()
       }, {
-        "tiny_py.assign"() ({
-          "tiny_py.binaryoperation"() ({
-            "tiny_py.var"() {"variable" = "val"} : () -> ()
+        "tiny_py.assign"() <{"var_name" = "val"}> ({
+          "tiny_py.binaryoperation"() <{"op" = "add"}> ({
+            "tiny_py.var"() <{"variable" = "val"}> : () -> ()
           }, {
-            "tiny_py.var"() {"variable" = "add_val"} : () -> ()
-          }) {"op" = "add"} : () -> ()
-        }) {"var_name" = "val"} : () -> ()
-      }) {"variable" = "a"} : () -> ()
-      "tiny_py.call_expr"() ({
-        "tiny_py.var"() {"variable" = "val"} : () -> ()
-      }) {"func" = "print", "type" = !empty, "builtin" = #bool<"True">} : () -> ()
-    }) {"fn_name" = "ex_two", "return_var" = !empty, "args" = []} : () -> ()
+            "tiny_py.var"() <{"variable" = "add_val"}> : () -> ()
+          }) : () -> ()
+        }) : () -> ()
+      }) : () -> ()
+      "tiny_py.call_expr"() <{"func" = "print", "type" = !tiny_py.empty, "builtin" = #tiny_py.bool"True"}> ({
+        "tiny_py.var"() <{"variable" = "val"}> : () -> ()
+      }) : () -> ()
+    }) : () -> ()
   }) : () -> ()
-}) : () -> ()
+}
 ```
 
 ## Lowering to the standard dialects
@@ -173,37 +178,40 @@ In [exercise one](https://github.com/xdslproject/training-intro/blob/main/practi
 
 If you open the _tiny_py_to_standard.py_ file which is in the _src_ folder at the top level of the practical directory, then you will see the activities being undertaken to lower our _tiny_py_ dialect down to the standard MLIR dialects. Whilst this isn't particularly complicated, there is a reasonable amount going on in order to lower the different aspects.
 
-Our objective is to transform the _Loop_ operation in our tiny py dialect into the _for_ operation of the standard _scf_ dialect, and if you look at line 173 of the [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py) file then you will see that we have started off the definition of this conversion. This function is below, with the comment _Needs to be completed!_ highlighting the parts that are missing and you need to add:
+Our objective is to transform the _Loop_ operation in our tiny py dialect into the _for_ operation of the standard _scf_ dialect, and if you look at line 188 of the [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py) file then you will see that we have started off the definition of this conversion. This function is below, with the comment _Needs to be completed!_ highlighting the parts that are missing and you need to add:
 
 ```python
 def translate_loop(ctx: SSAValueCtx,
                   loop_stmt: tiny_py.Loop) -> List[Operation]:    
 
     # First off lets translate the from (start) and to (end) expressions of the loop
-    start_expr, start_ssa=translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
-    end_expr, end_ssa=None, None # Needs to be completed!
+    start_expr, start_ssa = translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
+    end_expr, end_ssa = None, None  # Needs to be completed!
+    
     # The scf.for operation requires indexes as the type, so we cast these to
     # the indextype using the IndexCastOp of the arith dialect
-    start_cast = arith.IndexCastOp.get(start_ssa, IndexType())
-    end_cast = None # Needs to be completed!
+    start_cast = arith.IndexCastOp(start_ssa, IndexType())
+    end_cast = None  # Needs to be completed!
+    
     # The scf.for operation requires a step (number of iterations to increment
     # each iteration, we just create this as 1)
-    step_op = arith.Constant.create(attributes={"value": IntegerAttr.from_index_int_value(1)}, result_types=[IndexType()])
+    step_op = arith.Constant.create(attributes={"value": IntegerAttr.from_index_int_value(1)},
+                                    result_types=[IndexType()])
 
     # This is slightly more complex, we need to provide as arguments to the block
     # variables which are updated and then yield these out. We use a visitor
     # to visit all assignments and gather the names of the variables that are assigned
-    assigned_var_finder=GetAssignedVariables()
+    assigned_var_finder = GetAssignedVariables()
     for op in loop_stmt.body.blocks[0].ops:
         assigned_var_finder.traverse(op)
 
     # Based on the above information we build the list of block arguments, the first
     # element is always the operand which represents the current loop iteration
     # which is of type index
-    block_arg_types=[IndexType()]
-    block_args=[]
+    block_arg_types = [IndexType()]
+    block_args = []
     for var_name in assigned_var_finder.assigned_vars:
-        block_arg_types.append(ctx[StringAttr(var_name)].typ)
+        block_arg_types.append(ctx[StringAttr(var_name)].type)
         block_args.append(ctx[StringAttr(var_name)])
 
     # Create the block with our arguments, we will be putting into here the
@@ -215,38 +223,38 @@ def translate_loop(ctx: SSAValueCtx,
     # to the block
     c = SSAValueCtx(dictionary=dict(), parent_scope=ctx)
     for idx, var_name in enumerate(assigned_var_finder.assigned_vars):
-      c[StringAttr(var_name)]=block.args[idx+1]
+        c[StringAttr(var_name)] = block.args[idx + 1]
 
     # Now lets visit each operation in the loop body and build up the operations
     # which will be added to the block
     ops: List[Operation] = []
     for op in loop_stmt.body.blocks[0].ops:
-        pass # Needs to be completed!        
+        pass  # Needs to be completed!
 
     # We need to yield out assigned variables at the end of the block
-    yield_stmt=generate_yield(c, assigned_var_finder.assigned_vars)
-    block.add_ops(ops+[yield_stmt])
-    body=Region()
+    yield_stmt = generate_yield(c, assigned_var_finder.assigned_vars)
+    block.add_ops(ops + [yield_stmt])
+    body = Region()
     body.add_block(block)
 
     # Build the for loop operation here
-    for_loop=None # Needs to be completed!
+    for_loop = None  # Needs to be completed!
 
     # From now on, whenever the code references any variable that was assigned
     # in the body of the loop we need to use the corresponding loop result
     for i, var_name in enumerate(assigned_var_finder.assigned_vars):
-      ctx[StringAttr(var_name)]=for_loop.results[i]
+        ctx[StringAttr(var_name)] = for_loop.results[i]
 
-    return start_expr+end_expr+[start_cast, end_cast, step_op, for_loop]
+    return start_expr + end_expr + [start_cast, end_cast, step_op, for_loop]
 ```
 
-There is quite a bit going on here, so let's first complete the missing parts and then we will explore what the other aspects are doing too. You can see at line 181 of this file the line `end_expr, end_ssa=None, None # Needs to be completed!`. This is for handling the upper loop bounds which is an expression, and we need to call the corresponding function to convert this from the tiny py dialect into the standard dialects. You can see from the line above how this is handled for start, or from, expression, and here we can do very similar for this end expression using `loop_stmt.to_expr.blocks[0].ops.first` as the second argument to the `translate_expr` call. This `translate_expr` call returns two things, firstly the operations that the _to_ expression corresponds to, and secondly the resulting SSA value that can be used by subsequent operations to reference this.
+There is quite a bit going on here, so let's first complete the missing parts and then we will explore what the other aspects are doing too. You can see at line 196 of this file the line `end_expr, end_ssa = None, None  # Needs to be completed!`. This is for handling the upper loop bounds which is an expression, and we need to call the corresponding function to convert this from the tiny py dialect into the standard dialects. You can see from the line above how this is handled for start, or from, expression, and here we can do very similar for this end expression using `loop_stmt.to_expr.blocks[0].ops.first` as the second argument to the `translate_expr` call. This `translate_expr` call returns two things, firstly the operations that the _to_ expression corresponds to, and secondly the resulting SSA value that can be used by subsequent operations to reference this.
 
-Based upon how we have expressed this, the _start_ssa_ and _end_ssa_ values are of type integer, and the _for_ operation of the _scf_ dialect requires the lower and upper loop bound operands to be of type _index_ . Therefore we need to issue an operation that converts from an _integer_ to and _index_. If you look at line 185 of the file (line 10 of the snippet above) you will see the line `end_cast = None # Needs to be completed!` . The line above issues this conversion for _start_ssa_, so by following what was done there you should issue the same conversion operation for _end_ssa_.
+Based upon how we have expressed this, the _start_ssa_ and _end_ssa_ values are of type integer, and the _for_ operation of the _scf_ dialect requires the lower and upper loop bound operands to be of type _index_ . Therefore we need to issue an operation that converts from an _integer_ to and _index_. If you look at line 201 of the file (line 10 of the snippet above) you will see the line `end_cast = None  # Needs to be completed!` . The line above issues this conversion for _start_ssa_, so by following what was done there you should issue the same conversion operation for _end_ssa_.
 
-In the code above you can see that we create the _ops_ list (line 219 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py), and iterate through the operations of the loop body, but currently do not do anything with them. We therefore need to complete this, and to do that you call the _translate_stmt_ function with the SSA context _ctx_, and _op_ operation. The result from this call, which is a list, should then be added to the _ops_ list in the next line (e.g. if the result from the _translate_stmt_ function call is assigned to _stmt_ops_, then the code to add this would be `ops += stmt_ops`). 
+In the code above you can see that we create the _ops_ list (line 237 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py), and iterate through the operations of the loop body, but currently do not do anything with them. We therefore need to complete this, and to do that you call the _translate_stmt_ function with the SSA context _c_, and _op_ operation. The result from this call, which is a list, should then be added to the _ops_ list in the next line (e.g. if the result from the _translate_stmt_ function call is assigned to _stmt_ops_, then the code to add this would be `ops += stmt_ops`). 
 
-Now we have done all of this we just need to create the _for_ operation in the _scf_ dialect, this missing code is towards the end of the snippet above (`for_loop=None # Needs to be completed!`) and at line 230 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py). To create the operation we will call the _get_ method of the _for_ operations, i.e. `scf.For.get(..)` and provide to this operation five arguments. These arguments are the SSA result of the _start_cast_ operation, the SSA result of the _end_cast_ operation, the SSA result of the _step_op_ operation (which defines the step increment each iteration), _block_args_ (which we will describe in a moment), and _body_ which is a list of operations comprising the body of the loop. _block_args_ and _body_ can be passed directly as arguments 4 and 5, whereas for the other arguments we need to look up the SSA value from the operation which is avilable in the `results` member. For instance, for _start_cast_ you would pass `_start_cast.results[0]`.
+Now we have done all of this we just need to create the _for_ operation in the _scf_ dialect, this missing code is towards the end of the snippet above (`for_loop = None  # Needs to be completed!`) and at line 248 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py). To create the operation we will call the constructor of the _for_ operations, i.e. `scf.For(..)` and provide to this operation five arguments. These arguments are the SSA result of the _start_cast_ operation, the SSA result of the _end_cast_ operation, the SSA result of the _step_op_ operation (which defines the step increment each iteration), _block_args_ (which we will describe in a moment), and _body_ which is a list of operations comprising the body of the loop. _block_args_ and _body_ can be passed directly as arguments 4 and 5, whereas for the other arguments we need to look up the SSA value from the operation which is available in the `results` member. For instance, for _start_cast_ you would pass `start_cast.results[0]`.
 
 We have completed the missing parts and are now ready to run the translation pass and output MLIR formatted IR:
 
@@ -257,31 +265,29 @@ user@login01:~$ tinypy-opt output.mlir -p tiny-py-to-standard
 You should see the following generated, where you can see the for loop from the scf dialect which contains the loop bounds and body.
 
 ```
-"builtin.module"() ({
-  "func.func"() ({
-    %0 = "arith.constant"() {"value" = 0.0 : f32} : () -> f32
-    %1 = "arith.constant"() {"value" = 88.2 : f32} : () -> f32
-    %2 = "arith.constant"() {"value" = 0 : i32} : () -> i32
-    %3 = "arith.constant"() {"value" = 100000 : i32} : () -> i32
-    %4 = "arith.index_cast"(%2) : (i32) -> index
-    %5 = "arith.index_cast"(%3) : (i32) -> index
-    %6 = "arith.constant"() {"value" = 1 : index} : () -> index
-    %7 = "scf.for"(%4, %5, %6, %0) ({
-    ^0(%8 : index, %9 : f32):
-      %10 = "arith.addf"(%9, %1) : (f32, f32) -> f32
-      "scf.yield"(%10) : (f32) -> ()
-    }) : (index, index, index, f32) -> f32
-    %11 = "llvm.mlir.addressof"() {"global_name" = @str0} : () -> !llvm.ptr<!llvm.array<3 x i8>>
-    %12 = "llvm.getelementptr"(%11) {"rawConstantIndices" = array<i32: 0, 0>} : (!llvm.ptr<!llvm.array<3 x i8>>) -> !llvm.ptr<i8>
-    %13 = "arith.extf"(%7) : (f32) -> f64
-    "func.call"(%12, %13) {"callee" = @printf} : (!llvm.ptr<i8>, f64) -> ()
-    "func.return"() : () -> ()
-  }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "public"} : () -> ()
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<3 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "%f\n", "unnamed_addr" = 0 : i64} : () -> ()
-  "func.func"() ({
-  }) {"sym_name" = "printf", "function_type" = (!llvm.ptr<i8>, f64) -> (), "sym_visibility" = "private"} : () -> ()
-}) : () -> ()
+builtin.module {
+  func.func @main() {
+    %0 = arith.constant 0.000000e+00 : f32
+    %1 = arith.constant 8.820000e+01 : f32
+    %2 = arith.constant 0 : i32
+    %3 = arith.constant 100000 : i32
+    %4 = arith.index_cast %2 : i32 to index
+    %5 = arith.index_cast %3 : i32 to index
+    %6 = arith.constant 1 : index
+    %7 = scf.for %8 = %4 to %5 step %6 iter_args(%9 = %0) -> (f32) {
+      %10 = arith.addf %9, %1 : f32
+      scf.yield %10 : f32
+    }
+    %11 = "llvm.mlir.addressof"() <{"global_name" = @str0}> : () -> !llvm.ptr<!llvm.array<3 x i8>>
+    %12 = "llvm.getelementptr"(%11) <{"rawConstantIndices" = array<i32: 0, 0>}> : (!llvm.ptr<!llvm.array<3 x i8>>) -> !llvm.ptr<i8>
+    %13 = arith.extf %7 : f32 to f64
+    func.call @printf(%12, %13) : (!llvm.ptr<i8>, f64) -> ()
+    func.return
+  }
+  "llvm.mlir.global"() <{"global_type" = !llvm.array<3 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "%f\n", "unnamed_addr" = 0 : i64}> ({
+  }) : () -> ()
+  func.func private @printf(!llvm.ptr<i8>, f64) -> ()
+}
 ```
 
 >**Not sure or having problems?**
@@ -292,16 +298,15 @@ You should see the following generated, where you can see the for loop from the 
 We have skipped over some of the details in this function that are worth highlighting. In a loop, or any region that is being iterated upon, values will likely change from one iteration to the next. Therefore we need to define which values are updated and ensure that these are being used per iteration. Therefore blocks can have arguments and the following snippet, taken from the IR above illustrates this.
 
 ```
-%7 = "scf.for"(%4, %5, %6, %0) ({
-    ^0(%8 : index, %9 : f32):
-      %10 = "arith.addf"(%9, %1) : (f32, f32) -> f32
-      "scf.yield"(%10) : (f32) -> ()
-    }) : (index, index, index, f32) -> f32
+%7 = scf.for %8 = %4 to %5 step %6 iter_args(%9 = %0) -> (f32) {
+   %10 = arith.addf %9, %1 : f32
+   scf.yield %10 : f32
+}
 ```
 
-Here we have the _for_ operation, with the lower bound, upper bound, and step passes as arguments. But furthermore, you can see _%0_ is also passed as an argument and this is the initial value of _val_ that we will be incrementing. The line below, `^0(%8 : index, %9 : f32):` defines a block with arguments provided to the block. With a _for_ operation, the first argument to it's body's block is the loop index (_%8_) and the second argument onwards are SSA values that are inputs to the block. At the end of this block you can see the _yield_ operation, with _%10_, the result of the floating point addition, as an argument. Effectively, this will set _%10_ to be the result of a single execution of the block, and on the next iteration of the loop the block argument (_%9%_) will refer to this value rather than the initial value of _%0_ that was provided. After the last iteration of the _for_ operation, this yielded value is set as the result of the entire _for_ operation as _%7_. Zero, one or more SSA values can be yielded from a block.
+Here we have the _for_ operation, with the lower bound, upper bound, and step passes as arguments. But furthermore, you can see _%0_ is also passed as an argument and this is the initial value of _val_ that we will be incrementing. Inside the curly braces we have the body's block. With a _for_ operation, the first argument to it's body's block is the loop index (_%8_) and the second argument onwards are SSA values that are inputs to the block. At the end of this block you can see the _yield_ operation, with _%10_, the result of the floating point addition, as an argument. Effectively, this will set _%10_ to be the result of a single execution of the block, and on the next iteration of the loop the block argument (_%9%_) will refer to this value rather than the initial value of _%0_ that was provided. After the last iteration of the _for_ operation, this yielded value is set as the result of the entire _for_ operation as _%7_. Zero, one or more SSA values can be yielded from a block.
 
-The challenge is knowing which SSA values need to be included in the block as arguments, which need to be yielded, and then later on in the IR (e.g. when calling the _printf_ function) using the SSA value resulting from the loop rather than the initial SSA value. This is what the other parts of the _translate_loop_ function are doing, where we have written a simple _GetAssignedVariables_ visitor (which can be seen at line 32 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py)) which will visit all assignments to track which variables are updated. These are then used as the block and yield operation arguments.
+The challenge is knowing which SSA values need to be included in the block as arguments, which need to be yielded, and then later on in the IR (e.g. when calling the _printf_ function) using the SSA value resulting from the loop rather than the initial SSA value. This is what the other parts of the _translate_loop_ function are doing, where we have written a simple _GetAssignedVariables_ visitor (which can be seen at line 36 of [tiny_py_to_standard.py](https://github.com/xdslproject/training-intro/blob/main/practical/src/tiny_py_to_standard.py)) which will visit all assignments to track which variables are updated. These are then used as the block and yield operation arguments.
 
 ## Compile and run
 

--- a/practical/two/sample_solutions/python_compiler.py
+++ b/practical/two/sample_solutions/python_compiler.py
@@ -29,7 +29,7 @@ def python_compile(func):
         # Now we use the xDSL printer to output our built IR to stdio
         printer = Printer(stream=sys.stdout)
         printer.print_op(tiny_py_ir)
-        print("") # Adds a new line
+        print("") # Gives us a new line
 
         f = open("output.mlir", "w")
         printer_file = Printer(stream=f)
@@ -57,7 +57,7 @@ class Analyzer(ast.NodeVisitor):
         Handle assignment, we visit the RHS and then create the tiny_py Assign IR operation
         """
         val=self.visit(node.value)
-        return tiny_py.Assign.get(node.targets[0].id, val)
+        return tiny_py.Assign(node.targets[0].id, val)
 
     def visit_Module(self, node):
         """
@@ -67,7 +67,7 @@ class Analyzer(ast.NodeVisitor):
         contents=[]
         for a in node.body:
             contents.append(self.visit(a))
-        return tiny_py.Module.get(contents)
+        return tiny_py.Module(contents)
 
     def visit_FunctionDef(self, node):
         """
@@ -77,33 +77,44 @@ class Analyzer(ast.NodeVisitor):
         """
         contents=[]
         for a in node.body:
-            contents.append(self.visit(a))
-        return tiny_py.Function.get(node.name, None, [], contents)
+            operation=self.visit(a)
+            if operation is not None:
+                # We only need this check because we return None from our mocked out loop
+                # parser function that you will complete in exercise two,
+                # so we don't want to include that in the operations
+                contents.append(operation)
+        return tiny_py.Function(node.name, None, [], contents)
 
     def visit_Constant(self, node):
         """
         A literal constant value
         """
-        return tiny_py.Constant.get(node.value)
+        return tiny_py.Constant(node.value)
 
     def visit_Name(self, node):
         """
         Variable name
         """
-        return tiny_py.Var.get(node.id)
+        return tiny_py.Var(node.id)
 
     def visit_For(self, node):
         """
         Handles a for loop, note that we make life simpler here by assuming that
         it is in the format for i in range(from, to), and that is where we get
         the from and to expressions.
+
+        This function currently visits all the children in the loop body and
+        appends their operations to the contents list. It also obtains the operations
+        that represent the from and to expressions.
         """
         contents=[]
         for a in node.body:
             contents.append(self.visit(a))
         expr_from=self.visit(node.iter.args[0])
         expr_to=self.visit(node.iter.args[1])
-        return tiny_py.Loop.get(node.target.id, expr_from, expr_to, contents)
+
+        # Now you need to construct the tiny_py Loop and return it
+        return tiny_py.Loop(node.target.id, expr_from, expr_to, contents)
 
     def visit_BinOp(self, node):
         """
@@ -114,7 +125,7 @@ class Analyzer(ast.NodeVisitor):
             raise Exception("Operation "+str(node.op)+" not recognised")
         lhs=self.visit(node.left)
         rhs=self.visit(node.right)
-        return tiny_py.BinaryOperation.get(op_str, lhs, rhs)
+        return tiny_py.BinaryOperation(op_str, lhs, rhs)
 
     def visit_Call(self, node):
         """
@@ -125,7 +136,7 @@ class Analyzer(ast.NodeVisitor):
         for arg in node.args:
             arguments.append(self.visit(arg))
         builtin_fn=self.isFnCallBuiltIn(node.func.id)
-        return tiny_py.CallExpr.get(node.func.id, arguments, builtin=builtin_fn)
+        return tiny_py.CallExpr(node.func.id, arguments, builtin=builtin_fn)
 
     def visit_Expr(self, node):
         """

--- a/practical/two/sample_solutions/tiny_py.py
+++ b/practical/two/sample_solutions/tiny_py.py
@@ -4,10 +4,11 @@ from typing import List
 
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, ArrayAttr, AnyAttr, FloatAttr
 from xdsl.ir import Data, Operation, ParametrizedAttribute, Dialect, TypeAttribute
-from xdsl.irdl import (AnyOf, Region, Block, irdl_attr_definition,
-                        irdl_op_definition, OpAttr, IRDLOperation)
+from xdsl.irdl import (AnyOf, region_def, Block, Region, irdl_attr_definition,
+                        irdl_op_definition, prop_def, IRDLOperation)
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.traits import NoTerminator, IsTerminator
 
 """
 This is our bespoke Python dialect that we are calling tiny_py. As you will see it is
@@ -15,13 +16,14 @@ rather limited but is sufficient for our needs, and being simple means that we c
 navigate it and understand what is going on.
 """
 
+
 @irdl_attr_definition
 class BoolType(Data[bool]):
     """
     Represents a boolean, MLIR does not by default have a boolean (it uses integer 1 and 0)
     and-so this can be useful in your own dialects
     """
-    name = "bool"
+    name = "tiny_py.bool"
     data: bool
 
     @staticmethod
@@ -39,13 +41,15 @@ class BoolType(Data[bool]):
     def from_bool(data: bool) -> BoolType:
         return BoolType(data)
 
+
 @irdl_attr_definition
 class EmptyType(ParametrizedAttribute, TypeAttribute):
     """
     This represents an empty value, can be useful where you
     need a placeholder to explicitly denote that something is not filled
     """
-    name="empty"
+    name = "tiny_py.empty"
+
 
 @irdl_op_definition
 class Module(IRDLOperation):
@@ -53,16 +57,21 @@ class Module(IRDLOperation):
     A Python module, this is the top level Python container which is a region
     """
     name = "tiny_py.module"
+    traits = frozenset(
+        [
+            NoTerminator(),
+            IsTerminator()
+        ]
+    )
 
-    children: Region
+    children = region_def()
 
-    @staticmethod
-    def get(contents: List[Operation],
-            verify_op: bool = True) -> FileContainer:
-        res = Module.build(regions=[contents])
+    def __init__(self, contents: List[Operation], verify_op: bool = True):
+        super().__init__(regions=[contents])
+
         if verify_op:
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Function(IRDLOperation):
@@ -72,31 +81,38 @@ class Function(IRDLOperation):
     attributes and a region for the body
     """
     name = "tiny_py.function"
+    traits = frozenset([NoTerminator()])
 
-    fn_name: OpAttr[StringAttr]
-    args: OpAttr[ArrayAttr]
-    return_var: OpAttr[AnyAttr()]
-    body: Region
+    fn_name = prop_def(StringAttr)
+    args = prop_def(ArrayAttr)
+    return_var = prop_def(AnyAttr())
+    body = region_def()
 
-    @staticmethod
-    def get(fn_name: str | StringAttr,
-            return_var: Operation | None,
-            args: List[Operation],
-            body: List[Operation],
-            verify_op: bool = True) -> Routine:
+    def __init__(
+        self,
+        fn_name: str | StringAttr,
+        return_var: Operation | None,
+        args: List[Operation],
+        body: List[Operation],
+        verify_op: bool = True
+    ):
         if isinstance(fn_name, str):
             # If fn_name is a string then wrap it in StringAttr
-            fn_name=StringAttr(fn_name)
+            fn_name = StringAttr(fn_name)
 
         if return_var is None:
             # If return is None then use the empty token placeholder
-            return_var=EmptyType()
-        res = Function.build(attributes={"fn_name": fn_name, "return_var": return_var,
-                            "args": ArrayAttr(args)}, regions=[Region([Block(body)])])
+            return_var = EmptyType()
+
+        super().__init__(
+            properties={"fn_name": fn_name, "return_var": return_var, "args": ArrayAttr(args)},
+            regions=[Region([Block(body)])]
+        )
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Assign(IRDLOperation):
@@ -108,24 +124,25 @@ class Assign(IRDLOperation):
     more flexible, but adds additional complexity in the code so we keep it simple here.
     """
     name = "tiny_py.assign"
+    traits = frozenset([NoTerminator()])
 
-    var_name: OpAttr[StringAttr]
-    value: Region
+    var_name = prop_def(StringAttr)
+    value = region_def()
 
-    @staticmethod
-    def get(var_name: str | StringAttr,
-            value: Operation,
-            verify_op: bool = True) -> Assign:
-
+    def __init__(self,
+                 var_name: str | StringAttr,
+                 value: Operation,
+                 verify_op: bool = True):
         if isinstance(var_name, str):
             # If var_name is a string then wrap it in StringAttr
-            var_name=StringAttr(var_name)
+            var_name = StringAttr(var_name)
 
-        res = Assign.build(attributes={"var_name":var_name}, regions=[Region([Block([value])])])
+        super().__init__(properties={"var_name": var_name}, regions=[Region([Block([value])])])
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Loop(IRDLOperation):
@@ -138,31 +155,36 @@ class Loop(IRDLOperation):
     regions (the from and to expressions, and loop body)
     """
     name = "tiny_py.loop"
+    traits = frozenset([NoTerminator()])
 
-    variable: OpAttr[StringAttr]
-    from_expr: Region
-    to_expr: Region
-    body: Region
+    variable = prop_def(StringAttr)
+    from_expr = region_def()
+    to_expr = region_def()
+    body = region_def()
 
-    @staticmethod
-    def get(variable: str | StringAttr,
-            from_expr: Operation,
-            to_expr: Operation,
-            body: List[Operation],
-            verify_op: bool = True) -> If:
+    def __init__(self,
+                 variable: str | StringAttr,
+                 from_expr: Operation,
+                 to_expr: Operation,
+                 body: List[Operation],
+                 verify_op: bool = True):
         # We need to wrap from_expr and to_expr in lists because they are defined as separate regions
         # and a region is a block with a list of operations. This is not needed for body because it is
         # already a list of operations
         if isinstance(variable, str):
             # If variable is a string then wrap it in StringAttr
-            variable=StringAttr(variable)
+            variable = StringAttr(variable)
 
-        res = Loop.build(attributes={"variable": variable}, regions=[Region([Block([from_expr])]),
-            Region([Block([to_expr])]), Region([Block(body)])])
+        super().__init__(properties={"variable": variable},
+                         regions=[
+                             Region([Block([from_expr])]),
+                             Region([Block([to_expr])]),
+                             Region([Block(body)])
+                         ])
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Var(IRDLOperation):
@@ -173,20 +195,21 @@ class Var(IRDLOperation):
     """
     name = "tiny_py.var"
 
-    variable: OpAttr[StringAttr]
+    variable = prop_def(StringAttr)
 
-    @staticmethod
-    def get(variable : str | StringAttr,
-            verify_op: bool = True) -> If:
+    def __init__(self,
+                 variable: str | StringAttr,
+                 verify_op: bool = True):
+
         if isinstance(variable, str):
             # If variable is a string then wrap it in StringAttr
-            variable=StringAttr(variable)
+            variable = StringAttr(variable)
 
-        res = Var.build(attributes={"variable": variable})
+        super().__init__(properties={"variable": variable})
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
 
 @irdl_op_definition
 class BinaryOperation(IRDLOperation):
@@ -195,26 +218,30 @@ class BinaryOperation(IRDLOperation):
     and the LHS and RHS expressions as regions
     """
     name = "tiny_py.binaryoperation"
+    traits = frozenset([NoTerminator()])
 
-    op: OpAttr[StringAttr]
-    lhs: Region
-    rhs: Region
+    op = prop_def(StringAttr)
+    lhs = region_def()
+    rhs = region_def()
 
-    @staticmethod
-    def get(op: str | StringAttr,
-            lhs: Operation,
-            rhs: Operation,
-            verify_op: bool = True) -> BinaryExpr:
+    def __init__(self,
+                 op: str | StringAttr,
+                 lhs: Operation,
+                 rhs: Operation,
+                 verify_op: bool = True):
         if isinstance(op, str):
             # If op is a string then wrap it in StringAttr
-            op=StringAttr(op)
+            op = StringAttr(op)
 
-        res = BinaryOperation.build(attributes={"op": op}, regions=[Region([Block([lhs])]),
-                Region([Block([rhs])])])
+        super().__init__(
+            properties={"op": op},
+            regions=[Region([Block([lhs])]), Region([Block([rhs])])]
+        )
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Constant(IRDLOperation):
@@ -222,13 +249,13 @@ class Constant(IRDLOperation):
     A constant value, we currently support integers, floating points, and strings
     """
     name = "tiny_py.constant"
+    value = prop_def(AnyOf([StringAttr, IntegerAttr, FloatAttr]))
 
-    value: OpAttr[AnyOf([StringAttr, IntegerAttr, FloatAttr])]
+    def __init__(self,
+                 value: None | bool | int | str | float,
+                 width: int = 32,
+                 verify_op: bool = True):
 
-    @staticmethod
-    def get(value: None | bool | int | str | float, width=None,
-            verify_op: bool = True) -> Literal:
-        if width is None: width=32
         if type(value) is int:
             attr = IntegerAttr.from_int_and_width(value, width)
         elif type(value) is float:
@@ -237,11 +264,13 @@ class Constant(IRDLOperation):
             attr = StringAttr(value)
         else:
             raise Exception(f"Unknown constant of type {type(value)}")
-        res = Constant.create(attributes={"value": attr})
+
+        super().__init__(properties={"value": attr})
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
+
 
 @irdl_op_definition
 class Return(IRDLOperation):
@@ -250,6 +279,7 @@ class Return(IRDLOperation):
     any values/expressions at the moment
     """
     name = "tiny_py.return"
+
 
 @irdl_op_definition
 class CallExpr(IRDLOperation):
@@ -261,43 +291,50 @@ class CallExpr(IRDLOperation):
     and lastly the arguments to pass which are enclosed in a region.
     """
     name = "tiny_py.call_expr"
+    traits = frozenset([NoTerminator()])
 
-    func: OpAttr[StringAttr]
-    builtin: OpAttr[BoolType]
-    type:  OpAttr[AnyOf([AnyAttr(), EmptyType])]
-    args: Region
+    func = prop_def(StringAttr)
+    builtin = prop_def(BoolType)
+    type = prop_def(AnyOf([AnyAttr(), EmptyType]))
+    args = region_def()
 
-    @staticmethod
-    def get(func: str | StringAttr,
-            args: List[Operation],
-            type=EmptyType(),
-            builtin: bool =False,
-            verify_op: bool = True) -> CallExpr:
+    def __init__(self,
+                 func: str | StringAttr,
+                 args: List[Operation],
+                 type=EmptyType(),
+                 builtin: bool = False,
+                 verify_op: bool = True):
 
         if isinstance(func, str):
             # If func is a string then wrap it in StringAttr
-            func=StringAttr(func)
+            func = StringAttr(func)
 
-        builtin=BoolType(builtin)
+        builtin = BoolType(builtin)
 
-        # By default the type is empty attribute as the default is to call as a statement
-        res = CallExpr.build(regions=[Region([Block(args)])], attributes={"func": func, "type": type, "builtin": builtin})
+        super().__init__(
+            regions=[Region([Block(args)])],
+            properties={"func": func, "type": type, "builtin": builtin}
+        )
+
         if verify_op:
             # We don't verify nested operations since they might have already been verified
-            res.verify(verify_nested_ops=False)
-        return res
+            self.verify(verify_nested_ops=False)
 
-tinyPyIR = Dialect([
-    Module,
-    Function,
-    Return,
-    Constant,
-    Assign,
-    Loop,
-    Var,
-    BinaryOperation,
-    CallExpr,
-], [
-    BoolType,
-    EmptyType,
-])
+
+tinyPyIR = Dialect(
+    "tiny_py",
+    [
+        Module,
+        Function,
+        Return,
+        Constant,
+        Assign,
+        Loop,
+        Var,
+        BinaryOperation,
+        CallExpr,
+    ], [
+        BoolType,
+        EmptyType,
+    ]
+)

--- a/practical/two/sample_solutions/tiny_py_to_standard.py
+++ b/practical/two/sample_solutions/tiny_py_to_standard.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 from xdsl.dialects.builtin import (StringAttr, ModuleOp, IntegerAttr, IntegerType,
-      ArrayAttr, i32, i64, f32, f64, IndexType, DictionaryAttr,
-      Float16Type, Float32Type, Float64Type, FloatAttr, UnitAttr,
-      DenseIntOrFPElementsAttr, VectorType, SymbolRefAttr)
+                                   ArrayAttr, i32, i64, f32, f64, IndexType, DictionaryAttr,
+                                   Float16Type, Float32Type, Float64Type, FloatAttr, UnitAttr,
+                                   DenseIntOrFPElementsAttr, VectorType, SymbolRefAttr)
 from xdsl.dialects import func, arith, cf, memref, scf, llvm
-from xdsl.ir import Operation, Attribute, ParametrizedAttribute, Region, Block, SSAValue, BlockArgument, MLContext
+from xdsl.ir import Operation, Attribute, ParametrizedAttribute, Region, Block, SSAValue, BlockArgument
+from xdsl.context import MLContext
+from xdsl.traits import IsTerminator
+
 import tiny_py
 from xdsl.passes import ModulePass
 from util.list_ops import flatten
@@ -21,22 +24,24 @@ to generate and executable
 
 # A match between operation names and their standard dialect representations, there are
 # two entries for each representing the integer and float corresponding operation
-binary_arith_op_matching={"add": [arith.Addi, arith.Addf], "sub":[arith.Subi, arith.Subf],
-                          "mult": [arith.Muli, arith.Mulf], "div": [arith.DivSI, arith.Divf]}
+binary_arith_op_matching = {"add": [arith.Addi, arith.Addf], "sub": [arith.Subi, arith.Subf],
+                            "mult": [arith.Muli, arith.Mulf], "div": [arith.DivSI, arith.Divf]}
 
-builtin_function_name_mapping={"print": "printf"}
+builtin_function_name_mapping = {"print": "printf"}
 
-string_index=0
-global_declarations=[]
+string_index = 0
+global_declarations = []
+
 
 class GetAssignedVariables(Visitor):
-  def __init__(self):
-    self.assigned_vars=[]
+    def __init__(self):
+        self.assigned_vars = []
 
-  def traverse_assign(self, assign:tiny_py.Assign):
-    var_name=assign.var_name.data
-    if var_name not in self.assigned_vars:
-      self.assigned_vars.append(var_name)
+    def traverse_assign(self, assign: tiny_py.Assign):
+        var_name = assign.var_name.data
+        if var_name not in self.assigned_vars:
+            self.assigned_vars.append(var_name)
+
 
 @dataclass
 class SSAValueCtx:
@@ -61,18 +66,21 @@ class SSAValueCtx:
         self.dictionary[identifier] = ssa_value
 
     def copy(self):
-      ssa=SSAValueCtx()
-      ssa.dictionary=dict(self.dictionary)
-      return ssa
+        ssa = SSAValueCtx()
+        ssa.dictionary = dict(self.dictionary)
+        return ssa
 
-def translate_program(input_module: Module) -> ModuleOp:
+
+def translate_program(input_module: ModuleOp) -> ModuleOp:
     # create an empty global context
     global_ctx = SSAValueCtx()
     body = Region()
     block = Block()
     for top_level_entry in input_module.ops:
-      for module in top_level_entry.children.blocks[0].ops:
-        translate_toplevel(global_ctx, module, block)
+        assert isinstance(top_level_entry, tiny_py.Module)
+        top_level_entry: tiny_py.Module
+        for module in top_level_entry.children.blocks[0].ops:
+            translate_toplevel(global_ctx, module, block)
 
     assert (len(block.ops)) == 1 and isinstance(block.ops.first, func.FuncOp)
 
@@ -80,16 +88,18 @@ def translate_program(input_module: Module) -> ModuleOp:
     body.add_block(block)
     return ModuleOp(body)
 
+
 def translate_toplevel(ctx: SSAValueCtx, op: Operation, block) -> Operation:
     if isinstance(op, tiny_py.Function):
         block.add_op(translate_fun_def(ctx, op))
 
+
 def translate_fun_def(ctx: SSAValueCtx,
-                      fn_def: tinypy.Function) -> Operation:
+                      fn_def: tiny_py.Function) -> Operation:
     """
     Translates a function definition into the func standard dialect
     """
-    routine_name = fn_def.attributes["fn_name"]
+    routine_name = fn_def.properties["fn_name"]
 
     body = Region()
     block = Block()
@@ -97,12 +107,12 @@ def translate_fun_def(ctx: SSAValueCtx,
     # Create a new nested scope and relate parameter identifiers with SSA values of block arguments
     c = SSAValueCtx(dictionary=dict(), parent_scope=ctx)
 
-    arg_types=[]
-    arg_names=[]
+    arg_types = []
+    arg_names = []
 
-    body_contents=[]
+    body_contents = []
     for op in fn_def.body.blocks[0].ops:
-        res=translate_def_or_stmt(c, op)
+        res = translate_def_or_stmt(c, op)
         if res is not None:
             body_contents.append(res)
 
@@ -116,10 +126,11 @@ def translate_fun_def(ctx: SSAValueCtx,
     # To keep it very simple we have an empty list of arguments to our function definition
     # Also to keep it simple we hard code the name to be main, as this is the program
     # entry point (could instead use routine_name.data to obtain the string value)
-    function_ir=func.FuncOp.from_region("main", arg_types, [], body)
-    function_ir.attributes["sym_visibility"]=StringAttr("public")
+    function_ir = func.FuncOp.from_region("main", arg_types, [], body)
+    function_ir.attributes["sym_visibility"] = StringAttr("public")
 
     return function_ir
+
 
 def translate_def_or_stmt(ctx: SSAValueCtx,
                           op: Operation) -> List[Operation]:
@@ -131,6 +142,7 @@ def translate_def_or_stmt(ctx: SSAValueCtx,
         return ops
     # operation must have been translated by now
     raise Exception(f"Could not translate `{op}' as a definition or statement")
+
 
 def try_translate_stmt(ctx: SSAValueCtx,
                        op: Operation) -> Optional[List[Operation]]:
@@ -150,8 +162,9 @@ def try_translate_stmt(ctx: SSAValueCtx,
 
     return None
 
+
 def translate_stmt(ctx: SSAValueCtx,
-                  op: Operation) -> List[Operation]:
+                   op: Operation) -> List[Operation]:
     """
     Translates op as a statement.
     If op is an expression, returns a list of the translated Operations.
@@ -163,6 +176,7 @@ def translate_stmt(ctx: SSAValueCtx,
     else:
         return ops
 
+
 def translate_return(ctx: SSAValueCtx,
                      return_stmt: tiny_py.Return) -> List[Operation]:
     """
@@ -170,37 +184,41 @@ def translate_return(ctx: SSAValueCtx,
     """
     return [func.Return.get([])]
 
+
 def translate_loop(ctx: SSAValueCtx,
-                  loop_stmt: tiny_py.Loop) -> List[Operation]:
+                   loop_stmt: tiny_py.Loop) -> List[Operation]:
     """
     Translates a loop into the standard dialect scf while construct
     """
 
     # First off lets translate the from (start) and to (end) expressions of the loop
-    start_expr, start_ssa=translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
-    end_expr, end_ssa=translate_expr(ctx, loop_stmt.to_expr.blocks[0].ops.first)
+    start_expr, start_ssa = translate_expr(ctx, loop_stmt.from_expr.blocks[0].ops.first)
+    end_expr, end_ssa = translate_expr(ctx, loop_stmt.to_expr.blocks[0].ops.first)
+
     # The scf.for operation requires indexes as the type, so we cast these to
     # the indextype using the IndexCastOp of the arith dialect
-    start_cast = arith.IndexCastOp.get(start_ssa, IndexType())
-    end_cast = arith.IndexCastOp.get(end_ssa, IndexType())
+    start_cast = arith.IndexCastOp(start_ssa, IndexType())
+    end_cast = arith.IndexCastOp(end_ssa, IndexType())
+
     # The scf.for operation requires a step (number of iterations to increment
     # each iteration, we just create this as 1)
-    step_op = arith.Constant.create(attributes={"value": IntegerAttr.from_index_int_value(1)}, result_types=[IndexType()])
+    step_op = arith.Constant.create(properties={"value": IntegerAttr.from_index_int_value(1)},
+                                    result_types=[IndexType()])
 
     # This is slightly more complex, we need to provide as arguments to the block
     # variables which are updated and then yield these out. We use a visitor
     # to visit all assignments and gather the names of the variables that are assigned
-    assigned_var_finder=GetAssignedVariables()
+    assigned_var_finder = GetAssignedVariables()
     for op in loop_stmt.body.blocks[0].ops:
         assigned_var_finder.traverse(op)
 
     # Based on the above information we build the list of block arguments, the first
     # element is always the operand which represents the current loop iteration
     # which is of type index
-    block_arg_types=[IndexType()]
-    block_args=[]
+    block_arg_types = [IndexType()]
+    block_args = []
     for var_name in assigned_var_finder.assigned_vars:
-        block_arg_types.append(ctx[StringAttr(var_name)].typ)
+        block_arg_types.append(ctx[StringAttr(var_name)].type)
         block_args.append(ctx[StringAttr(var_name)])
 
     # Create the block with our arguments, we will be putting into here the
@@ -212,7 +230,7 @@ def translate_loop(ctx: SSAValueCtx,
     # to the block
     c = SSAValueCtx(dictionary=dict(), parent_scope=ctx)
     for idx, var_name in enumerate(assigned_var_finder.assigned_vars):
-      c[StringAttr(var_name)]=block.args[idx+1]
+        c[StringAttr(var_name)] = block.args[idx + 1]
 
     # Now lets visit each operation in the loop body and build up the operations
     # which will be added to the block
@@ -222,25 +240,26 @@ def translate_loop(ctx: SSAValueCtx,
         ops += stmt_ops
 
     # We need to yield out assigned variables at the end of the block
-    yield_stmt=generate_yield(c, assigned_var_finder.assigned_vars)
-    block.add_ops(ops+[yield_stmt])
-    body=Region()
+    yield_stmt = generate_yield(c, assigned_var_finder.assigned_vars)
+    block.add_ops(ops + [yield_stmt])
+    body = Region()
     body.add_block(block)
 
     # Build the for loop operation here
-    for_loop=scf.For.get(start_cast.results[0], end_cast.results[0], step_op.results[0], block_args, body)
+    for_loop = scf.For(start_cast.results[0], end_cast.results[0], step_op.results[0], block_args, body)
 
     # From now on, whenever the code references any variable that was assigned
     # in the body of the loop we need to use the corresponding loop result
     for i, var_name in enumerate(assigned_var_finder.assigned_vars):
-      ctx[StringAttr(var_name)]=for_loop.results[i]
+        ctx[StringAttr(var_name)] = for_loop.results[i]
 
-    return start_expr+end_expr+[start_cast, end_cast, step_op, for_loop]
+    return start_expr + end_expr + [start_cast, end_cast, step_op, for_loop]
+
 
 def generate_yield(ctx: SSAValueCtx, assigned_vars) -> List[Operation]:
     """
       Generates a yield statement for exiting a block, this exposes
-      the updated variables to their origional values.
+      the updated variables to their original values.
       It is required because in SSA form when we update a
       variable it creates a new SSA element, and it is this
       element that then needs to be used as the program progresses.
@@ -249,26 +268,28 @@ def generate_yield(ctx: SSAValueCtx, assigned_vars) -> List[Operation]:
       it's FIR dialect which will explicitly allocate
       a variable and then store into it whenever it is updated.
     """
-    yield_list=[]
+    yield_list = []
     for var_name in assigned_vars:
         yield_list.append(ctx[StringAttr(var_name)])
 
-    return scf.Yield.get(*yield_list)
+    return scf.Yield(*yield_list)
+
 
 def translate_assign(ctx: SSAValueCtx,
-                      assign: tiny_py.Assign) -> List[Operation]:
+                     assign: tiny_py.Assign) -> List[Operation]:
     """
     Translates assignment
     """
     var_name = assign.var_name
     assert isinstance(var_name, StringAttr)
 
-    expr, ssa=translate_expr(ctx, assign.value.blocks[0].ops.first)
+    expr, ssa = translate_expr(ctx, assign.value.blocks[0].ops.first)
 
     # Always update the SSA context as it is this new SSA element that subsequent references
     # to the variable should reference
     ctx[var_name] = ssa
     return expr
+
 
 def translate_call_expr_stmt(ctx: SSAValueCtx,
                              call_expr: tiny_py.CallExpr, is_expr=False) -> List[Operation]:
@@ -285,59 +306,61 @@ def translate_call_expr_stmt(ctx: SSAValueCtx,
         op, arg = translate_expr(ctx, arg)
         if op is not None: ops += op
         args.append(arg)
-        arg_types.append(arg.typ)
+        arg_types.append(arg.type)
 
     # For now we limit the number of arguments to a function to one
     # Could easily remove this restriction but makes life easier with
     # the printf function
     assert len(args) == len(arg_types) == 1
 
-    name = call_expr.attributes["func"].data
+    name = call_expr.properties["func"].data
 
     if call_expr.builtin.data and name in builtin_function_name_mapping:
         # If this is a built in function and that name is in the mapping dictionary
         # then replace the name, for instance translating print to printf
-        name=builtin_function_name_mapping[name]
+        name = builtin_function_name_mapping[name]
 
     if name == "printf":
         # For printf if it is not a string then we need to store and pass the
         # C conversion string
-        conv_string=get_printf_conversion_string(args[0].typ)
+        conv_string = get_printf_conversion_string(args[0].type)
         if conv_string is not None:
-          conv_ops, conv_ssa = translate_string_into_global_and_get_element_ptr(conv_string)
-          args.insert(0, conv_ssa)
-          arg_types.insert(0, conv_ssa.typ)
-          ops+=conv_ops
+            conv_ops, conv_ssa = translate_string_into_global_and_get_element_ptr(conv_string)
+            args.insert(0, conv_ssa)
+            arg_types.insert(0, conv_ssa.type)
+            ops += conv_ops
 
-          if args[1].typ == f32:
-            # LLVM's printf only accepts doubles, therefore need to cast
-            # a single precision floating point to double
-            arg_cast=arith.ExtFOp.get(args[1], f64)
-            ops.append(arg_cast)
-            args[1]=arg_cast.results[0]
-            arg_types[1]=f64
+            if args[1].type == f32:
+                # LLVM's printf only accepts doubles, therefore need to cast
+                # a single precision floating point to double
+                arg_cast = arith.ExtFOp(args[1], f64)
+                ops.append(arg_cast)
+                args[1] = arg_cast.results[0]
+                arg_types[1] = f64
 
     if is_expr:
-        result_type=try_translate_type(call_expr.type)
-        call = func.Call.create(attributes={"callee": SymbolRefAttr(name)},
+        result_type = try_translate_type(call_expr.type)
+        call = func.Call.create(properties={"callee": SymbolRefAttr(name)},
                                 operands=args, result_types=[result_type])
     else:
-        call = func.Call.create(attributes={"callee": SymbolRefAttr(name)},
+        call = func.Call.create(properties={"callee": SymbolRefAttr(name)},
                                 operands=args, result_types=[])
     ops.append(call)
 
     if call_expr.builtin.data:
-      global_declarations.append(func.FuncOp.external(name, arg_types, []))
+        global_declarations.append(func.FuncOp.external(name, arg_types, []))
 
     return ops
 
+
 def get_printf_conversion_string(arg_type):
     if arg_type == f32 or arg_type == f64:
-      return "%f"
+        return "%f"
     elif arg_type == i32 or arg_type == i64:
-      return "%d"
+        return "%d"
     else:
-      return None
+        return None
+
 
 def translate_expr(ctx: SSAValueCtx,
                    op: Operation) -> Tuple[List[Operation], SSAValue]:
@@ -353,6 +376,7 @@ def translate_expr(ctx: SSAValueCtx,
     else:
         ops, ssa_value = res
         return ops, ssa_value
+
 
 def try_translate_expr(ctx: SSAValueCtx,
                        op: Operation) -> Optional[Tuple[List[Operation], SSAValue]]:
@@ -376,68 +400,72 @@ def try_translate_expr(ctx: SSAValueCtx,
 
     return None
 
+
 def translate_constant(op: tiny_py.Constant) -> Operation:
     """
     Translates a constant, literal, depending upon its type
     """
-    value = op.attributes["value"]
+    value = op.properties["value"]
 
     if isinstance(value, StringAttr):
         return translate_string_into_global_and_get_element_ptr(value.data)
 
     if isinstance(value, FloatAttr):
-        const= arith.Constant.create(attributes={"value": value},
-                                         result_types=[value.type])
+        const = arith.Constant.create(properties={"value": value},
+                                      result_types=[value.type])
         return [const], const.results[0]
 
     if isinstance(value, IntegerAttr):
-        const= arith.Constant.create(attributes={"value": value},
-                                         result_types=[value.typ])
+        const = arith.Constant.create(properties={"value": value},
+                                      result_types=[value.type])
         return [const], const.results[0]
 
     raise Exception(f"Could not translate `{op}' as a literal")
 
+
 def translate_string_into_global_and_get_element_ptr(string_val: str):
     global string_index
 
-    string_identifier="str"+str(string_index)
-    string_index+=1
+    string_identifier = "str" + str(string_index)
+    string_index += 1
 
-    value=StringAttr(string_val+"\n")
-    global_type=llvm.LLVMArrayType.from_size_and_type(len(value.data), IntegerType(8))
-    global_op=llvm.GlobalOp.get(global_type, string_identifier, "internal", 0, True, value=value, unnamed_addr=0)
+    value = StringAttr(string_val + "\n")
+    global_type = llvm.LLVMArrayType.from_size_and_type(len(value.data), IntegerType(8))
+    global_op = llvm.GlobalOp(global_type, string_identifier, "internal", 0, True, value=value, unnamed_addr=0)
     global_declarations.append(global_op)
 
-    global_lookup=llvm.AddressOfOp.get(string_identifier, llvm.LLVMPointerType.typed(global_type))
-    element_pointer=llvm.GEPOp.get(global_lookup.results[0], llvm.LLVMPointerType.typed(IntegerType(8)), [0,0])
+    global_lookup = llvm.AddressOfOp(string_identifier, llvm.LLVMPointerType.typed(global_type))
+    element_pointer = llvm.GEPOp(global_lookup.results[0], [0, 0], None, llvm.LLVMPointerType.typed(IntegerType(8)))
     return [global_lookup, element_pointer], element_pointer.results[0]
+
 
 def translate_binary_expr(ctx: SSAValueCtx,
                           op: Operation) -> Operation:
     """
     Translates a binary expression
     """
-    lhs, lhs_ssa=translate_expr(ctx, op.lhs.blocks[0].ops.first)
-    rhs, rhs_ssa=translate_expr(ctx, op.rhs.blocks[0].ops.first)
-    operand_type = lhs_ssa.typ
+    lhs, lhs_ssa = translate_expr(ctx, op.lhs.blocks[0].ops.first)
+    rhs, rhs_ssa = translate_expr(ctx, op.rhs.blocks[0].ops.first)
+    operand_type = lhs_ssa.type
     if op.op.data in binary_arith_op_matching:
         # We match here on the LHS type, for a more advanced coverage if the types are different
         # then we should convert the lower to the higher type, but we ignore that in our simple example
-        if isinstance(operand_type, IntegerType): index=0
+        if isinstance(operand_type, IntegerType): index = 0
         if isinstance(operand_type, Float16Type) or isinstance(operand_type, Float32Type
-                        ) or isinstance(operand_type, Float64Type): index=1
-        op_instance=binary_arith_op_matching[op.op.data][index]
-        assert op_instance is not None, "Operation "+op.op.data+" not implemented for type"
-        bin_op=op_instance.get(lhs_ssa, rhs_ssa)
+                                                               ) or isinstance(operand_type, Float64Type): index = 1
+        op_instance = binary_arith_op_matching[op.op.data][index]
+        assert op_instance is not None, "Operation " + op.op.data + " not implemented for type"
+        bin_op = op_instance(lhs_ssa, rhs_ssa)
         return [bin_op], bin_op.results[0]
     else:
         raise Exception(f"Could not translate operation `{op.op.data}' as it is unknown")
 
-@dataclass
+
+@dataclass(frozen=True)
 class LowerTinyPyToStandard(ModulePass):
+    name = 'tiny-py-to-standard'
 
-  name = 'tiny-py-to-standard'
-
-  def apply(self, ctx: MLContext, input_module: ModuleOp):
-      res_module = translate_program(input_module)
-      res_module.regions[0].move_blocks(input_module.regions[0])
+    def apply(self, ctx: MLContext, input_module: ModuleOp):
+        res_module = translate_program(input_module)
+        res_module.regions[0].move_blocks(input_module.regions[0])
+        input_module.regions[0].detach_block(0)


### PR DESCRIPTION
Updates the dialect code, compiler code, and markdown tutorials for xdsl 0.23.0. The slides aren't updated, nor has it been tested using a up-to-date version of MLIR. 